### PR TITLE
Unbind unsafe APIs (load/loadstring) in bbslua.

### DIFF
--- a/mbbsd/bbslua.c
+++ b/mbbsd/bbslua.c
@@ -977,8 +977,12 @@ bbsluaRegConst(lua_State *L)
 
     // unbind unsafe API
     lua_pushnil(L); lua_setglobal(L, "dofile");
-    lua_pushnil(L); lua_setglobal(L, "load");
     lua_pushnil(L); lua_setglobal(L, "loadfile");
+
+    // Loading bytecode is dangerous.
+    // Lua 5.1 has a vulnerable bytecode verifier.
+    // Lua 5.2 even removed the verifier.
+    lua_pushnil(L); lua_setglobal(L, "load");
     lua_pushnil(L); lua_setglobal(L, "loadstring");
 
     // global

--- a/mbbsd/bbslua.c
+++ b/mbbsd/bbslua.c
@@ -977,7 +977,9 @@ bbsluaRegConst(lua_State *L)
 
     // unbind unsafe API
     lua_pushnil(L); lua_setglobal(L, "dofile");
+    lua_pushnil(L); lua_setglobal(L, "load");
     lua_pushnil(L); lua_setglobal(L, "loadfile");
+    lua_pushnil(L); lua_setglobal(L, "loadstring");
 
     // global
     lua_pushcfunction(L, bl_print);


### PR DESCRIPTION
這兩個函數因為可以 load(undump) bytecode 有些安全疑慮，建議拿掉。

掃了一下 BBSLua 板看起來應該沒什麼人用這兩個函數，如果確定要拔掉的話記得要把置底文裡面的

>  dofile / loadfile 無法使用 (但 load/loadstring 可使用)

也要改。
