### PR TITLE
replace thread with future and list with vector

### DIFF
--- a/daemon/boardd/server.cpp
+++ b/daemon/boardd/server.cpp
@@ -171,7 +171,7 @@ void start_server(const char *host, unsigned short port) {
     futures.reserve(NUM_THREADS);
     for (std::size_t i = 0; i < NUM_THREADS; ++i) {
 	futures.emplace_back(
-		std::async(std::launch::async,ServiceThread,std::ref(io_service)));
+		std::async(std::launch::async, ServiceThread, std::ref(io_service)));
     }
     for (auto &fut : futures) {
 	fut.get();

--- a/daemon/boardd/server.cpp
+++ b/daemon/boardd/server.cpp
@@ -171,7 +171,8 @@ void start_server(const char *host, unsigned short port) {
     futures.reserve(NUM_THREADS);
     for (std::size_t i = 0; i < NUM_THREADS; ++i) {
 	futures.emplace_back(
-		std::async(std::launch::async, ServiceThread, std::ref(io_service)));
+		std::async(std::launch::async,
+		           ServiceThread,std::ref(io_service)));
     }
     for (auto &fut : futures) {	//TODO remove the for loop after C++14 (it is redundant)
 	fut.get();

--- a/daemon/boardd/server.cpp
+++ b/daemon/boardd/server.cpp
@@ -3,9 +3,9 @@
 #include <iostream>
 #include <memory>
 #include <functional>
-#include <list>
-#include <thread>
+#include <future>
 #include <mutex>
+#include <vector>
 #include <boost/asio.hpp>
 extern "C" {
 #include <event2/buffer.h>
@@ -165,14 +165,15 @@ void start_server(const char *host, unsigned short port) {
     std::cerr << "boardd: built with mulit-threading, "
 	<< NUM_THREADS << " threads." << std::endl;
 
-    std::list<std::thread> threads;
     asio::io_service io_service;
     Server server(io_service, host, port);
-    for (int i = 0; i < NUM_THREADS; ++i) {
-	threads.push_back(std::move(
-		std::thread(std::bind(&ServiceThread, std::ref(io_service)))));
+    std::vector<std::future> futures;
+    futures.reserve(NUM_THREADS);
+    for (std::size_t i = 0; i < NUM_THREADS; ++i) {
+	futures.emplace_back(
+		std::async(std::launch::async,ServiceThread,std::ref(io_service)));
     }
-    for (auto &thr : threads) {
-	thr.join();
+    for (auto &fut : futures) {
+	fut.get();
     }
 }

--- a/daemon/boardd/server.cpp
+++ b/daemon/boardd/server.cpp
@@ -173,7 +173,7 @@ void start_server(const char *host, unsigned short port) {
 	futures.emplace_back(
 		std::async(std::launch::async, ServiceThread, std::ref(io_service)));
     }
-    for (auto &fut : futures) {
+    for (auto &fut : futures) {	//TODO remove the for loop after C++14 (it is redundant)
 	fut.get();
     }
 }


### PR DESCRIPTION
1. remove header (list and thread)
2. add header (future and vector)
3. vector is faster than list if you know memory usage
4. future is enough if you don't call thread::native_handle (and faster than thread when constructing)
5. use size_t (or unsigned) to prevent NUM_THREADS greater than int range
6. for (auto &fut : futures)..., these code can remove safely after c++14
7. to make 6. safely, reorder code is necessary (make futures under server)
