### PR TITLE
Add Welly to origin whitelist

### DIFF
--- a/daemon/wsproxy/wsproxy.lua
+++ b/daemon/wsproxy/wsproxy.lua
@@ -7,7 +7,8 @@ local origin_whitelist = {
     ["http://www.ptt.cc"] = true,
     ["https://www.ptt.cc"] = true,
     ["https://robertabcd.github.io"] = true,
-    ["app://pcman"] = true,
+    ["app://pcman"] = true,    
+    ["app://welly"] = true,
 }
 
 function check_origin()


### PR DESCRIPTION
Welly now supports Websocket connection. It would be great if it can use its own application identity. It might also be helpful for PTT admin to differentiate WSS traffic by clients.