### PR TITLE
correct symlink of mail for TICKET

### DIFF
--- a/util/openticket.c
+++ b/util/openticket.c
@@ -252,7 +252,7 @@ int main()
 		strcpy(mymail.owner, BBSNAME);
 		sprintf(mymail.title, "[%s] ¤¤¼úÅo! $ %d", Cdatelite(&now), money * num);
 		unlink(genbuf);
-		Link("etc/ticket", genbuf);
+		Link( BBSHOME "/etc/ticket", genbuf);
                 sethomedir(genbuf, userid);
 		append_record(genbuf, &mymail, sizeof(mymail));
                 sendalert_uid(uid, ALERT_NEW_MAIL);


### PR DESCRIPTION
For solving the issue that user will see 
```
◆ 此封信無內容。                                              [按任意鍵繼續]
```
when they read their mail for getting money by TICKET(全站樂透).
also correct weird symbolic link referring to. (`/home/bbs/home/*/{userid}/etc/ticket`)