### PR TITLE
Add reply counter

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -226,7 +226,7 @@
 
 #define MAX_MODES	(127)
 #define MAX_RECOMMENDS  (100)
-#define MAX_REPLY_COUNTS  (65550)
+#define MAX_REPLY_COUNTS  (65500)
 
 #define STR_CURSOR      ">"
 #define STR_CURSOR2     "¡´"

--- a/include/common.h
+++ b/include/common.h
@@ -226,6 +226,7 @@
 
 #define MAX_MODES	(127)
 #define MAX_RECOMMENDS  (100)
+#define MAX_REPLY_COUNTS  (65550)
 
 #define STR_CURSOR      ">"
 #define STR_CURSOR2     "¡´"

--- a/include/modes.h
+++ b/include/modes.h
@@ -155,6 +155,8 @@
 #define RS_RECOMMEND	0x200	/* search by recommends */
 #define RS_MONEY	0x400	/* search by money */
 #define RS_SOLVED	0x800	/* search by 's' mark */
+#define RS_REPLY_COUNTER  0x1000  /* search by reply counts */
+
 
 #define CURSOR_FIRST    (RS_TITLE | RS_FIRST)
 #define CURSOR_NEXT     (RS_TITLE | RS_FORWARD)

--- a/include/pttstruct.h
+++ b/include/pttstruct.h
@@ -285,7 +285,8 @@ typedef struct fileheader_t { /* 128 bytes */
     }	    multi;		    /* rocker: if bit32 on ==> reference */
     /* XXX dirty, split into flag and money if money of each file is less than 16bit? */
     unsigned char   filemode;        /* must be last field @ boards.c */
-    char    pad3[3];
+    unsigned short int reply_counter;
+    char    pad3;
 } PACKSTRUCT fileheader_t;
 
 #define FILE_LOCAL      0x01    /* local saved,  non-mail */

--- a/mbbsd/bbs.c
+++ b/mbbsd/bbs.c
@@ -151,7 +151,7 @@ modify_dir_lite(
 	fhdr.recommend = recommend;
     }
 
-    if (reply)
+    if (reply && fhdr.reply_counter < MAX_RECOMMENDS)
         fhdr.reply_counter += 1;
 
 

--- a/mbbsd/read.c
+++ b/mbbsd/read.c
@@ -574,7 +574,7 @@ typedef struct filter_predicate_t {
     char keyword[TTLEN + 1];
     int recommend;
     int money;
-    int reply_counter;
+    unsigned short int reply_counter;
 } filter_predicate_t;
 
 static int
@@ -636,7 +636,7 @@ ask_filter_predicate(filter_predicate_t *pred, int prev_modes, int sr_mode,
             !getdata(b_lines, 0, (currmode & MODE_SELECT) ?
                      "Add Rule Reply: " : "Reply higher then: ",
                      keyword, 7, LCECHO) ||
-                (pred->reply_coutner = atoi(keyword)) == 0)
+                (pred->reply_counter = atoi(keyword)) == 0)
             return READ_REDRAW;
     } else {
 	// Ptt: only once for these modes.

--- a/mbbsd/read.c
+++ b/mbbsd/read.c
@@ -574,6 +574,7 @@ typedef struct filter_predicate_t {
     char keyword[TTLEN + 1];
     int recommend;
     int money;
+    int reply_counter;
 } filter_predicate_t;
 
 static int
@@ -630,6 +631,13 @@ ask_filter_predicate(filter_predicate_t *pred, int prev_modes, int sr_mode,
 	    (pred->money = atoi(keyword)) <= 0)
 	    return READ_REDRAW;
 	strcat(keyword, "M");
+    } else if (sr_mode & RS_REPLY_COUNTER) {
+        if (currstat == RMAIL ||
+            !getdata(b_lines, 0, (currmode & MODE_SELECT) ?
+                     "Add Rule Reply: " : "Reply higher then: ",
+                     keyword, 7, LCECHO) ||
+                (pred->reply_coutner = atoi(keyword)) == 0)
+            return READ_REDRAW;
     } else {
 	// Ptt: only once for these modes.
 	if (prev_modes & sr_mode &
@@ -672,6 +680,8 @@ match_filter_predicate(const fileheader_t *fh, void *arg)
 	    (fh->recommend <= pred->recommend);
     else if (sr_mode & RS_MONEY)
 	return query_file_money(fh) >= pred->money;
+    else if (sr_mode & RS_REPLY_COUNTER)
+        return atoi(fh->reply_counter) >= pred->reply_counter;
     return 0;
 }
 
@@ -947,6 +957,10 @@ i_read_key(const onekey_t * rcmdlist, keeploc_t * locmem,
 	case 'Z':
 	    mode = select_read(locmem, RS_RECOMMEND);
 	    break;
+
+        case 'J':
+            mode = select_read(locmem, RS_REPLY_COUNTER);
+            break;
 
         case 'a':
 	    mode = select_read(locmem, RS_AUTHOR);

--- a/util/pyutil/pttstruct.py
+++ b/util/pyutil/pttstruct.py
@@ -168,7 +168,8 @@ FILEHEADER_FMT = (
         ("pad2", "B"),
         ("multi", "i"),
         ("filemode", "B"),
-        ("pad3", "3s"))
+        ("reply_counter", "H"),
+        ("pad3", "s"))
 
 FILEHEADER_SIZE = 128
 


### PR DESCRIPTION
Idea from: [[建議] 搜尋「爭議」而不是「推文」數](https://www.ptt.cc/bbs/PttCurrent/M.1487635702.A.29F.html)

Using `fileheader_t` last three pads, split to `unsigned short int reply_counter` and `char pad`. Then it can record up to 65500 reply counts.

I'm not sure about the affect to change the `pad3` in `fileheader_t`, the comment of `filemode` says ` /* must be last field @ boards.c */`.
