### PR TITLE
refine initbbs and cross_post UI

### DIFF
--- a/mbbsd/bbs.c
+++ b/mbbsd/bbs.c
@@ -2154,7 +2154,7 @@ cross_post(int ent, fileheader_t * fhdr, const char *direct)
     // 反正本來就只是想解決「不小心」或是「假裝不小心」用到的情形。
     // tn_safe_strip_board(xtitle, xboard);
 
-    getdata(2, 0, "(S)存檔 (L)站內 (Q)取消？[Q] ", genbuf, 3, LCECHO);
+    getdata(2, 0, "(S/L)發文 (Q)取消？[Q] ", genbuf, 3, LCECHO);
 
     if (genbuf[0] != 'l' && genbuf[0] != 's')
         return FULLUPDATE;

--- a/mbbsd/mail.c
+++ b/mbbsd/mail.c
@@ -2035,7 +2035,7 @@ mail_cross_post(int unused_arg GCC_UNUSED, fileheader_t * fhdr,
     do_reply_title(2, fhdr->title, str_forward, xtitle, sizeof(xtitle));
     strip_ansi(xtitle, xtitle, STRIP_ALL);
 
-    getdata(2, 0, "(S)存檔 (L)站內 (Q)取消？[Q] ", genbuf, 3, LCECHO);
+    getdata(2, 0, "(S/L)發文 (Q)取消？[Q] ", genbuf, 3, LCECHO);
     if (genbuf[0] == 'l' || genbuf[0] == 's') {
 	int             currmode0 = currmode;
 

--- a/sample/pttbbs.conf
+++ b/sample/pttbbs.conf
@@ -77,9 +77,6 @@
 /* 若定義，該板發文不受行限或是可上傳 */
 #define BN_BBSMOVIE	    "BBSmovie"
 
-/* 若定義, 則以此為版名提供全站文摘 */
-#define BN_DIGEST BBSMNAME "Digest"
-
 // /* 若定義，則.... */
 // #define BN_WHOAMI "WhoAmI"
 

--- a/util/Makefile
+++ b/util/Makefile
@@ -84,7 +84,7 @@ install: $(PROGS)
 .endif
 
 clean:
-	rm -f *.o $(CPROGS) $(CPROG_WITH_UTIL) $(CPROG_WITHOUT_UTIL) $(CPP_WITH_UTIL)
+	rm -f *.o shmctl $(CPROGS) $(CPROG_WITH_UTIL) $(CPROG_WITHOUT_UTIL) $(CPP_WITH_UTIL)
 
 
 installfiltermail:

--- a/util/initbbs.c
+++ b/util/initbbs.c
@@ -190,15 +190,6 @@ static void initBoards() {
 	b.gid = 5;
 	newboard(fp, &b);
 	
-#ifdef BN_DIGEST
-	strcpy(b.brdname, BN_DIGEST);
-	strcpy(b.title, "文摘 ◎" BBSNAME "文摘 好文的收集地");
-	b.brdattr = BRD_POSTMASK;
-	b.level = PERM_SYSOP;
-	b.gid = 5;
-	newboard(fp, &b);
-#endif
-
 #ifdef BN_FIVECHESS_LOG
 	strcpy(b.brdname, BN_FIVECHESS_LOG);
 	strcpy(b.title, "棋藝 ◎" BBSNAME "五子棋譜 站上對局全紀錄");

--- a/util/initbbs.c
+++ b/util/initbbs.c
@@ -4,6 +4,7 @@ static void initDir() {
     Mkdir("adm");
     Mkdir("boards");
     Mkdir("etc");
+    Mkdir("log");
     Mkdir("man");
     Mkdir("man/boards");
     Mkdir("out");
@@ -229,16 +230,16 @@ static void initMan() {
 	fwrite(&f, sizeof(f), 1, fp);
 	Mkdir("man/boards/N/Note/SONGBOOK");
 	
-	strcpy(f.filename, "SONGO");
-	strcpy(f.title, "◆ <點歌> 動態看板");
-	fwrite(&f, sizeof(f), 1, fp);
-	Mkdir("man/boards/N/Note/SONGO");
-	
 	strcpy(f.filename, "SYS");
 	strcpy(f.title, "◆ <系統> 動態看板");
 	fwrite(&f, sizeof(f), 1, fp);
 	Mkdir("man/boards/N/Note/SYS");
-	
+		
+	strcpy(f.filename, "SONGO");
+	strcpy(f.title, "◆ <點歌> 動態看板");
+	fwrite(&f, sizeof(f), 1, fp);
+	Mkdir("man/boards/N/Note/SONGO");
+
 	strcpy(f.filename, "AD");
 	strcpy(f.title, "◆ <廣告> 動態看板");
 	fwrite(&f, sizeof(f), 1, fp);


### PR DESCRIPTION
1. mbbsd: use same style words with a8d77d5 in cross_post UI
2. initbbs: revise the order with folder entry of SONGO and SYS in board Note.
3. initbbs: BN_DIGEST(digest for whole site) is deprecated for sure. 
4. util/Makefile: let "make clean" can clean up util/shmctl (binary file) 