### PR TITLE
[WIP, DO NOT MERGE!] Hsiao.googletest2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 tags
 var.h
 /pttbbs.conf
+/pttbbs.cmake.conf
 /local.h
 common/sys/big5.c
 mbbsd/mbbsd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+project(pttbbs)
+
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,4 +2,47 @@ cmake_minimum_required(VERSION 2.6.4)
 
 project(pttbbs)
 
+message(STATUS "CMAKE_SYSTEM: ${CMAKE_SYSTEM}")
+message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+message(STATUS "CMAKE_SYSTEM_VERSION: ${CMAKE_SYSTEM_VERSION}")
+message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "CMAKE_C_COMPILER: ${CMAKE_C_COMPILER}")
+message(STATUS "CMAKE_C_COMPILER_ID: ${CMAKE_C_COMPILER_ID}")
+
+##########
+# pttbbs.cmake
+##########
+
+include("pttbbs.cmake")
+
+##########
+# for pttbbs.conf
+##########
+
+if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+    message(STATUS "CMAKE SYSTEM PROCESSOR is x86_64")
+    set(SHMALIGNEDSIZE 1)
+    set(SHM_MB_SIZE 4)
+
+    set(TIMET64 1)
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ia64")
+    message("CMAKE SYSTEM PROCESSOR is ia64")
+    set(SHMALIGNEDSIZE 1)
+    set(SHM_MB_SIZE 256)
+
+    set(TIMET64 1)
+endif()
+
+message(STATUS "SHM_MB_SIZE: ${SHM_MB_SIZE}")
+
+configure_file(pttbbs.cmake.conf ${CMAKE_SOURCE_DIR}/pttbbs.conf @ONLY)
+
+##########
+# sub-dirs
+##########
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+add_subdirectory(common)
+add_subdirectory(mbbsd)
+add_subdirectory(util)
 add_subdirectory(tests)

--- a/INSTALL.cmake.md
+++ b/INSTALL.cmake.md
@@ -1,0 +1,16 @@
+Build with CMake
+==========
+
+To build with CMake (in the root-dir of pttbbs):
+
+1. cp sample/pttbbs.cmake.conf ./
+2. mkdir -p build
+3. cd build
+4. cmake -DGTEST_DIR=/usr/src/gtest ..
+5. make
+
+Then you should be able to see the compiling process in the build dir.
+
+You can do the following before the above steps for clang in Ubuntu:
+
+`export CC=/usr/bin/clang; export CXX=/usr/bin/clang++`

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+add_subdirectory(bbs)
+add_subdirectory(osdep)
+add_subdirectory(sys)

--- a/common/bbs/CMakeLists.txt
+++ b/common/bbs/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+set(CMBBS_SRCS
+    log.c
+    money.c
+    names.c
+    path.c
+    time.c
+    string.c
+    fhdr_stamp.c
+    cache.c
+    passwd.c
+    filehdr.c
+    banip.c
+    )
+
+add_library(cmbbs STATIC ${CMBBS_SRCS})

--- a/common/osdep/CMakeLists.txt
+++ b/common/osdep/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+set(OSDEP_SRCS
+    cpuload.c
+    proctitle.c
+    strlcat.c
+    strlcpy.c
+    memusage.c
+    )
+
+add_library(osdep STATIC ${OSDEP_SRCS})
+link_directories(${CMAKE_CURRENT_BINARY_DIR})

--- a/common/sys/CMakeLists.txt
+++ b/common/sys/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+set(SYS_SRCS
+    daemon.c
+    file.c
+    lock.c
+    log.c
+    net.c
+    sort.c
+    string.c
+    time.c
+    crypt.c
+    record.c
+    vector.c
+    telnet.c
+    vbuf.c
+    vtkbd.c
+    utf8.c
+    big5.c
+    buffer.c
+    thttp.c
+    )
+
+file(COPY big5data.tar.bz2 DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+add_custom_command(OUTPUT big5.c
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/big5_gen.py > ${CMAKE_CURRENT_BINARY_DIR}/big5.c
+    )
+
+add_library(cmsys STATIC ${SYS_SRCS})

--- a/mbbsd/CMakeLists.txt
+++ b/mbbsd/CMakeLists.txt
@@ -1,0 +1,155 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+set(CORESRCS
+    bbs.c
+    announce.c
+    read.c
+    board.c
+    brc.c
+    mail.c
+    record.c
+    fav.c
+    )
+
+set(ABUSESRCS
+    captcha.c
+    )
+
+set(ACCSRCS
+    user.c
+    acl.c
+    register.c
+    passwd.c
+    emaildb.c
+    )
+
+set(NETSRCS
+    mbbsd.c
+    io.c
+    term.c
+    telnet.c
+    nios.c
+    )
+
+set(TALKSRCS
+    friend.c
+    talk.c
+    ccw.c
+    )
+
+set(UTILSRCS
+    stuff.c
+    kaede.c
+    convert.c
+    name.c
+    syspost.c
+    cache.c
+    cal.c
+    )
+
+set(UISRCS
+    menu.c
+    vtuikit.c
+    psb.c
+    )
+
+set(PAGERSRCS
+    more.c
+    pmore.c
+    )
+
+set(PLUGSRCS
+    ordersong.c
+    angel.c
+    timecap.c
+    )
+
+set(CHESSSRCS
+    chess.c
+    chc.c
+    chc_tab.c
+    ch_go.c
+    ch_gomo.c
+    ch_dark.c
+    ch_reversi.c
+    ch_conn6.c
+    )
+
+set(GAMESRCS
+    chicken.c
+    gamble.c
+    )
+
+set(OTHERSRCS
+    admin.c
+    assess.c
+    edit.c
+    xyz.c
+    var.c
+    vote.c
+    voteboard.c
+    comments.c
+    )
+
+set(SRCS
+    ${OTHERSRCS}
+    ${CORESRCS}
+    ${ABUSESRCS}
+    ${ACCSRCS}
+    ${NETSRCS}
+    ${TALKSRCS}
+    ${UTILSRCS}
+    ${UISRCS}
+    ${PAGERSRCS}
+    ${PLUGSRCS}
+    ${CHESSSRCS}
+    ${GAMESRCS})
+
+set(TESTSZSRCS
+    testsz.c
+    )
+
+if(${DIET})
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${PROJECT_SOURCE_DIR}/common/diet")
+    set(LDLIBS ${LDLIBS} "diet")
+    set(DIETCC "diet -Os")
+endif()
+
+# reduce .bss align overhead
+if(NOT (${DEBUG}) AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin"))
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--sort-common")
+endif()
+
+# bbslua
+if(${USE_BBSLUA})
+    if(${CMAKE_SYSTEM_NAME} == "FreeBSD")
+        set(LUA_PKG_NAME "lua-5.1")
+        set(LDLIBS "${LDLIBS} -Wl,--no-as-needed")
+    else()
+        set(LUA_PKG_NAME "lua5.1")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} -E pkg-config --cflags "${LUA_PKG_NAME}" OUTPUT_VARIABLE LUA_CFLAGS)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E pkg-config --libs "${LUA_PKG_NAME}" OUTPUT_VARIABLE LUA_LIBS)
+
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LUA_CFLAGS}")
+    set(LDLIBS "${LDLIBS} ${LUA_LIBS}")
+    set(SRCS ${SRCS} bbslua.c bbsluaext.c)
+endif()
+
+# pfterm
+if(${USE_PFTERM})
+    set(SRCS ${SRCS} pfterm.c)
+else()
+    set(SRCS ${SRCS} screen.c)
+endif()
+
+add_executable(testsz 
+    ${TESTSZSRCS}
+    )
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/vers.c
+    COMMAND sh ${PROJECT_SOURCE_DIR}/util/newvers.sh
+    DEPENDS ${PROJECT_SOURCE_DIR}/util/newvers.sh
+    )
+add_executable(mbbsd vers.c ${SRCS})
+target_link_libraries(mbbsd ${LDLIBS})

--- a/pttbbs.cmake
+++ b/pttbbs.cmake
@@ -1,0 +1,132 @@
+##########
+# BBSHOME
+##########
+
+set(BBSHOME "${HOME}")
+if("${BBSHOME}" STREQUAL "")
+    set(BBSHOME /home/bbs)
+endif()
+
+##########
+# Command build flags
+##########
+
+set(PTT_WARN "-W -Wall -Wunused -Wno-missing-field-initializers")
+set(PTT_CFLAGS "${PTT_WARN} -pipe -DBBSHOME='\"${BBSHOME}\"' -I${CMAKE_SOURCE_DIR}/include")
+set(PTT_CXXFLAGS "${PTT_WARN} -pipe -DBBSHOME='\"${BBSHOME}\"' -I${CMAKE_SOURCE_DIR}/include")
+set(PTT_LDFLAGS "-Wl,--as-needed")
+
+if(${CMAKE_C_COMPILER_ID} MATCHES "Clang")
+    message(STATUS "using clang")
+    set(PTT_CFLAGS "${PTT_CFLAGS} -Qunused-arguments -Wno-parentheses-equality -fcolor-diagnostics -Wno-invalid-source-encoding")
+endif()
+
+##########
+# Platform specific build flags
+##########
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+    message(STATUS "on MacOSX")
+    find_package(curses REQUIRED)
+
+    set(PTT_LDFLAGS "-Wl")
+
+    set(PTT_CFLAGS "${PTT_CFLAGS} -I/opt/local/include -I/usr/local/opt/ncurses/include -DNEED_SETPROCTITLE")
+    set(PTT_CXXFLAGS "${PTT_CXXFLAGS} -I/opt/local/include -I/usr/local/opt/ncurses/include")
+    set(PTT_LDFLAGS "${PTT_LDFLAGS} -L/usr/local/opt/ncurses/lib")
+    set(PTT_LDLIBS iconv ${CURSES_LIBRARIES})
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+    message(STATUS "on FreeBSD")
+    set(PTT_CFLAGS "${PTT_CFLAGS} -I/usr/local/include")
+    set(PTT_CXXFLAGS "${PTT_CXXFLAGS} -I/usr/local/include")
+    set(PTT_LDFLAGS "${PTT_LDFLAGS} -L/usr/local/lib")
+    set(PTT_LDLIBS kvm iconv)
+endif()
+
+##########
+# Profiling
+##########
+
+if(${PROFILING})
+    set(PTT_CFLAGS "${PTT_CFLAGS} -pg")
+    set(PTT_CXXFLAGS "${PTT_CXXFLAGS} -pg")
+    set(PTT_LDFLAGS "${PTT_LDFLAGS} -pg")
+    set(NO_OMITFP yes)
+    set(NO_FORK yes)
+endif()
+
+##########
+# Debug
+##########
+
+if(${DEBUG})
+    set(GDB 1)
+    set(PTT_CFLAGS "${PTT_CFLAGS} -DDEBUG")
+    set(PTT_CXXFLAGS "${PTT_CXXFLAGS} -DDEBUG")
+endif()
+
+##########
+# flags
+##########
+
+if(${GDB})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 ${PTT_CFLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 ${PTT_CXXFLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -O0 ${PTT_LDFLAGS}")
+    # set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -O0 ${PTT_LDFLAGS}")
+    SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
+    set(LDLIBS ${PTT_LDLIBS})
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Os ${PTT_CFLAGS} ${EXT_CFLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Os ${PTT_CXXFLAGS} ${EXT_CXXFLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Os ${PTT_LDFLAGS}")
+    # set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} -O0 ${PTT_LDFLAGS}")
+    SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
+    set(LDLIBS ${PTT_LDLIBS})
+
+    if(${OMITFP})
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fomit-frame-pointer")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fomit-frame-pointer")
+    endif()
+endif()
+
+##########
+# No-fork
+##########
+
+if(${NO_FORK})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNO_FORK")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_FORK")
+endif()
+
+##########
+# libevent
+##########
+
+execute_process(COMMAND pkg-config --cflags libevent
+    OUTPUT_VARIABLE LIBEVENT_CFLAGS
+    )
+execute_process(COMMAND pkg-config --libs-only-L libevent
+    OUTPUT_VARIABLE LIBEVENT_LIBS_L
+    )
+execute_process(COMMAND pkg-config --libs-only-l libevent
+    OUTPUT_VARIABLE LIBEVENT_LIBS_l
+    )
+
+##########
+# LDLIBS
+##########
+
+set(LDLIBS ${LDLIBS} cmbbs cmsys osdep)
+
+##########
+# var.h
+##########
+
+add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/include/var.h
+    COMMAND perl ${PROJECT_SOURCE_DIR}/util/parsevar.pl < ${CMAKE_SOURCE_DIR}/mbbsd/var.c > ${CMAKE_SOURCE_DIR}/include/var.h
+    DEPENDS ${PROJECT_SOURCE_DIR}/mbbsd/var.c
+    )
+
+add_custom_target(VAR_H ALL
+    DEPENDS ${PROJECT_SOURCE_DIR}/include/var.h)

--- a/sample/pttbbs.cmake.conf
+++ b/sample/pttbbs.cmake.conf
@@ -1,0 +1,279 @@
+/* 定義 BBS 站名位址 */
+#define BBSNAME         "新批踢踢"          /* 中文站名 */
+#define BBSENAME        "PTT2"              /* 英文站名 */
+#define MYHOSTNAME      "ptt2.cc"               /* 網路位址 */
+#define MYIP            "140.112.30.143"        /* IP位址 */
+
+/* 定義是否查詢文章的 web 版 URL，及 URL 用的 hostname/prefix */
+#define QUERY_ARTICLE_URL                   /* 是否提供查詢文章 URL */
+#define URL_PREFIX      "http://www.ptt.cc/bbs"        /* URL prefix */
+        /*
+                         http://www.ptt.cc/bbs/SYSOP/M.1197864962.A.476.html
+                         ^^^^^^^^^^^^^^^^^^^^^
+                         這個部分
+         */
+
+/* 下列資訊為系統效能，預設值為普通小系站規模 */
+ 
+/* 最多註冊人數, 每個人會用掉 21 bytes 的 shared-memory */
+#define MAX_USERS   (10000)
+
+/* 最多同時上線人數, 每個人會用掉 3456 bytes 的 shared-memory */
+#define MAX_ACTIVE  (512)
+
+/* 最大開板個數, 每個會用掉 6420 bytes 的 shared-memory */
+#define MAX_BOARD   (1024)
+
+/* 最大 CPU負荷, 超過的時候將拒絕 login */
+#define MAX_CPULOAD (300)
+
+
+/* BBSMNAME 是系統名，出現在系統寄信、通知等等。
+ * 現在你可以改變這個名字，但強烈建議名字別超過 3 個字元
+ * 請保持像 [Ptt系統警察] 這種仍能塞進 IDLEN 的格式
+ * 不然你的系統可能會有一堆作者切一半的系統信。 
+ * BBSMNAME2 則是出現在部份選單裡，建議盡量照原格式 4 字元寬
+ * MONEYNAME 是錢幣的名字，建議五個字元內
+ */
+#define BBSMNAME    "Ptt"
+#define BBSMNAME2   "Ｐtt"
+#define MONEYNAME   "Ptt幣"
+
+/* 定義系統資訊 */
+#define BBSUSER         "bbs"
+#define BBSUID          9999
+#define BBSGID          99
+
+/* *** 以下為預設板名 (見 include/config.h) *** */
+/* 安全紀錄 */
+#define BN_SECURITY     "Security"
+/* 動態看板的家 */
+#define BN_NOTE         "Note"
+/* 紀錄 */
+#define BN_RECORD       "Record"
+
+/* SYSOP 板 */
+#define BN_SYSOP        "SYSOP"
+/* 測試板 */
+#define BN_TEST     "Test"
+/* 發生錯誤時建議的回報板名為此板 */
+#define BN_BUGREPORT    BBSMNAME "Bug"
+/* 法律訴訟的板 */
+#define BN_LAW      BBSMNAME "Law"
+/* 新手板(會自動進我的最愛) */
+#define BN_NEWBIE       BBSMNAME "NewHand"
+/* 找看板(會自動進我的最愛) */
+#define BN_ASKBOARD     "AskBoard"
+/* 外國板 */
+#define BN_FOREIGN      BBSMNAME "Foreign"
+
+/* *** 以下為定義時會多出功能的板名 *** */
+
+/* 若定義, 提供美工特別用板 */
+#define BN_ARTDSN       "Artdsn"
+
+/* 若定義，該板發文不受行限或是可上傳 */
+#define BN_BBSMOVIE     "BBSmovie"
+
+/* 若定義, 則以此為版名提供全站文摘 */
+#define BN_DIGEST BBSMNAME "Digest"
+
+// /* 若定義，則.... */
+// #define BN_WHOAMI "WhoAmI"
+
+/* 若定義, 則全站所有五子棋/象棋棋譜都會紀錄在此板 */
+//#define BN_FIVECHESS_LOG BBSMNAME "Five"
+//#define BN_CCHESS_LOG    BBSMNAME "CChess"
+
+/* 若定義，則動態看板會動態檢查爭議性字眼 */
+//#define BN_NOTE_AGGCHKDIR "<點歌> 動態看板"
+
+/* 最大編輯行數, 以防有惡意使用者 post 巨大文章 */
+#define MAX_EDIT_LINE       (2048)
+#define MAX_EDIT_LINE_LARGE (32000)
+
+/* 若定義則啟用修文自動合併系統 */
+#define EDITPOST_SMARTMERGE
+
+/* 可以設定多重進站畫面 */
+#define MULTI_WELCOME_LOGIN
+
+/* 主題式閱讀搜尋範圍，文章多可試著加大，但小心對效能影響 */
+#define THREAD_SEARCH_RANGE (500)
+
+/* 幫忙寄信的 server, 一般設成自己(即ip: 127.0.0.1)就可以 */
+#define RELAY_SERVER_IP "127.0.0.1"
+
+/* 抬頭色彩 */
+#define TITLE_COLOR "\033[0;1;37;46m"
+
+/* 若定義, 則所有編輯文章最下方都會加入編輯來源.
+   否則只有 SYSOP板會加入來源                    */
+//#define ALL_REEDIT_LOG
+
+/* 定義看板好友名單將會在幾秒鐘後失效強迫重載 */
+#define HBFLexpire  (432000)
+
+/* 定義是否使用外籍使用者註冊
+   及外國人最長居留時間，之後需向站方申請永久居留權 */
+//#define FOREIGN_REG
+//#define FOREIGN_REG_DAY 30
+
+/* 板主可以按大寫 H切換隱形與否 */
+#define BMCHS
+
+/* 水球整理, 看板備份等等外部程式 */
+#define OUTJOBSPOOL
+
+/* 若定義, 則不能舉辦賭盤 */
+#define NO_GAMBLE
+
+/* 可動態透過 GLOBALVAR[9]調整使用者上限 */
+#define DYMAX_ACTIVE
+
+/* 程式每天最多可以跑多久 (in seconds) 因為有的時候會出現跑不停的 process */
+#define CPULIMIT_PER_DAY 30
+
+/* 若定義, 若程式失敗, 會等待 86400 秒以讓 gdb來 attach */
+#define DEBUGSLEEP
+
+/* 若定義, 在轉寄位址輸入錯誤時會有讓使用者回報訊息的提示 */
+/* 這個選項存在的原因是因為有部份使用者信誓旦旦說他們沒打錯但看不出程式錯誤 */
+//#define DEBUG_FWDADDRERR
+
+/* 若定義, 用一個奇怪的數字來檢查我的最愛和看板列表是否錯誤 */
+#define MEM_CHECK 0x98761234
+
+
+/* 若定義, 則可在外部 (shmctl cmsignal) 要求將 mbbsd將 zapbuf 釋放掉.
+   會使用非正規的記憶體要求函式. (目前只在 FreeBSD上測試過)
+   !!請注意!!
+   除非您確切知道這個能能在做什麼並且有須要,
+   否則請不要打開這個功能!!                                           */
+//#define CRITICAL_MEMORY
+
+/* 設定最大可再買幾封信箱 (default: 1000) */
+#define MAX_EXKEEPMAIL    (1000)
+
+/* 對於 port 23的, 會預先 fork 幾隻出來. 如此在系統負荷高的時候,
+   仍可有好的上站率 */
+//#define PRE_FORK 10
+
+/* 若定義, 則由 shmctl utmpsortd 將 time(NULL) 寫入 SHM->GV2.e.now,
+   則不須每個 mbbsd都自己透過 time(NULL) 取得時間, 導致大量的 system call.
+   須要加跑 shmctl timed 來提供時間                                        */
+//#define OUTTA_TIMER
+
+/* 若定義, 則開啟 Big5 轉 UTF-8 的功能 */
+#define CONVERT
+
+/* 若定義, 則在文章列表的時候不同日期會標上不同顏色 */
+//#define COLORDATE
+
+/* 若定義, 在使用者註冊之前, 會先顯示出該檔案, 經使用者確認後才能註冊 */
+//#define HAVE_USERAGREEMENT "etc/UserAgreement"
+//#define HAVE_USERAGREEMENT_VERSION "etc/UserAgreementVersion"
+//#define HAVE_USERAGREEMENT_ACCEPTABLE "etc/UserAgreementAcceptable"
+
+/* DBCS 相關設定 */
+/* DBCS Aware: 讓游標不會跑到 DBCS trailing bytes 上 */
+#define DBCSAWARE
+
+/* 若定義，guest 帳號預設不顯示一字雙色 */
+#define GUEST_DEFAULT_DBCS_NOINTRESC
+
+/* 使用新式的 pmore (piaip's more) 代替舊式 bug 抓不完的 more 或是簡易的 minimore */
+//#define USE_PMORE
+
+/* 使用 rfork()取代 fork() . 目前只在 FreeBSD上有效 */
+//#define USE_RFORK
+
+/* 使用 HUGETLB shared memory . 目前只在 Linux 上有效 */
+//#define USE_HUGETLB
+
+/* 在某些平台之下, shared-memory規定需要為一定的 aligned size,
+   如在 linux x86_64 下使用 HUGETLB 時需為 4MB aligned,
+   而在 linux ia64 下使用 HUGETLB時需為 256MB aligned.
+   單位為 bytes */
+#cmakedefine SHMALIGNEDSIZE (1048576*@SHM_MB_SIZE@) // 4MB for x86_64
+
+/* 讓過於熱門或被鬧的版冷靜, SHM 會變大一些些 */
+#define USE_COOLDOWN
+
+/* 若定義, 則在刪除看板文章的時候, 僅會在 .DIR 中標明, 並不會將該資料
+   從 .DIR 中拿掉. 可以避免多項問題 (尤其是熱門看板一堆推薦及編輯時)
+   須配合使用 (尚未完成)                                              */
+//#define SAFE_ARTICLE_DELETE
+
+/* 若定義, 則在傳送水球的時候, 不會直接 kill 該程序. 理論上可以減少大
+   量的系統負和                                                       */
+//#define NOKILLWATERBALL
+
+/* 若定義, 則在系統超過負荷的時候, 新接的連線會留住 OVERLOADBLOCKFDS
+   這麼多個 fd , 以避免使用者狂連造成更大的負荷 (default: 0)          */
+//#define OVERLOADBLOCKFDS 128
+
+/* 若定義, 則 SYSOP帳號並不會自動加上站長權限.
+   在第一次啟動時, 您並不能定義 (否則就拿不到站長權了) .
+   而在設定完成後, 若您站長帳號並不叫做 SYSOP,
+   則可透過 NO_SYSOP_ACCOUNT 關閉該帳號, 以避免安全問題發生.          */
+//#define NO_SYSOP_ACCOUNT
+
+/* 若定義, 則熱門看板列表會改用 shmctl utmpsortd 來計算, 而不是每
+   個使用者自己算. 在站上會同時有很多人同時跑去看熱門看板的時候用.
+   若站上並不會一瞬間很多人跑去看熱門看板, 會得到反效果.              */
+//#define HOTBOARDCACHE 128
+
+/* 在轉信時附上的時區. 若在台灣, 中國大陸等地, 用預設的即可.          */
+//#define INNTIMEZONE "+0800 (CST)"
+
+/* 開啟小天使小主人功能 */
+//#define PLAY_ANGEL
+
+/* 若定義, 則使用舊式推文 */
+#define OLDRECOMMEND
+
+/* 若定義, 則 guest 可推文，格式變為 IP+日期 */
+#define GUESTRECOMMEND
+
+/* 定義幾秒內算快速推文 */
+#define FASTRECMD_LIMIT (90)
+
+/* 若定義, 可設定轉錄自動在原文留下記錄 */
+#define USE_AUTOCPLOG
+
+/* 若定義, 新板設定自動開記錄，不過 USE_AUTOCPLOG 還是要開才有用 */
+#define DEFAULT_AUTOCPLOG
+
+/* 如果 time_t 是 8 bytes的話 (如 X86_64) */
+#cmakedefine TIMET64
+
+/* 使用 utmpd, 在外部運算好友資料, 如果您確定這個在做什麼才開啟 */
+//#define UTMPD
+//#define UTMPD_ADDR "192.168.0.1:5120"
+/* 在 cacheserver 上面擋掉狂上下站的使用者 */
+//#define NOFLOODING
+
+/* 使用 daemon/fromd, 使用外部daemon紀錄上站故鄉名稱 */
+//#define FROMD
+
+/* 若定義, 則不允許註冊 guest */
+//#define NO_GUEST_ACCOUNT_REG
+
+/* 若定義為 1, 則每篇發文會寫到 log/post , 可以給分析或張爸魔一類的程式用 */
+#define LOG_CONF_POST   (1)
+
+/* 限制一個email能註冊的帳號數量 (要使用請在make的時候加 WITH_EMAILDB) */
+#define EMAILDB_LIMIT 5
+
+//#define USE_REG_CAPTCHA
+//#define CAPTCHA_INSERT_SERVER_ADDR "127.0.0.1:80"
+//#define CAPTCHA_INSERT_HOST CAPTCHA_INSERT_SERVER_ADDR
+//#define CAPTCHA_INSERT_URI "/captcha/insert"
+//#define CAPTCHA_INSERT_SECRET ""
+//#define CAPTCHA_URL_PREFIX "https://www.ptt.cc/captcha"
+//#define CAPTCHA_CODE_LENGTH 32
+
+/* 前進站畫面 */
+#define INSCREEN \
+"前進站畫面 (請至 pttbbs.conf 修改您的前進站畫面)"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+add_subdirectory(${GTEST_DIR} lib/googletest)
+add_subdirectory(test_mbbsd)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,22 @@
+Unit-Test
+===========
+
+這個 unit-test 是 based on googletest. 在 ubuntu 裡使用 libgtest-dev. 並使用 cmake 來做 test 相關的 compile. 需要先做 code 的 make, 再做 test 的 cmake.
+
+Setup
+-----
+1. 在 ubuntu 裡:
+
+    `apt-get install -y libgtest-dev`
+
+2. 在 pttbbs 做 make
+
+3. 在 pttbbs `mkdir build`
+
+4. `cd build; cmake -DGTEST_DIR=/usr/src/googletest ..; make`
+
+TODO
+-----
+1. 將 cmake 弄完整.
+
+2. 考慮將 pttbbs 的 make 也整合進 cmake 裡.

--- a/tests/test_mbbsd/CMakeLists.txt
+++ b/tests/test_mbbsd/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+include_directories(${PROJECT_SOURCE_DIR}/include)
+
+link_directories(${PROJECT_SOURCE_DIR}/common/bbs)
+link_directories(${PROJECT_SOURCE_DIR}/common/sys)
+link_directories(${PROJECT_SOURCE_DIR}/common/osdep)
+
+add_executable(test_dummy
+    test_dummy.cc
+    )
+
+target_link_libraries(test_dummy gtest gtest_main cmbbs cmsys osdep)

--- a/tests/test_mbbsd/CMakeLists.txt
+++ b/tests/test_mbbsd/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.6.4)
 
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
-link_directories(${PROJECT_SOURCE_DIR}/common/bbs)
-link_directories(${PROJECT_SOURCE_DIR}/common/sys)
-link_directories(${PROJECT_SOURCE_DIR}/common/osdep)
-
 add_executable(test_dummy
     test_dummy.cc
     )
 
-target_link_libraries(test_dummy gtest gtest_main cmbbs cmsys osdep)
+target_link_libraries(test_dummy gtest gtest_main ${LDLIBS})

--- a/tests/test_mbbsd/test_dummy.cc
+++ b/tests/test_mbbsd/test_dummy.cc
@@ -1,0 +1,10 @@
+#include "gtest/gtest.h"
+
+TEST(dummy, dummy) {
+    EXPECT_EQ(0, 0);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}    

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,124 @@
+cmake_minimum_required(VERSION 2.6.4)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPTTBBS_UTIL")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(BBSBASE "${PROJECT_SOURCE_DIR}/include/var.h")
+set(UTILSRCS
+    util_var.c
+    )
+
+set(CPROG_WITH_UTIL
+    boardlist
+    post
+    poststat
+    account
+    deluserfile
+    expire
+    mandex
+    broadcast
+    openticket
+    topusr
+    toplazyBM
+    writemoney
+    reaper
+    buildAnnounce
+    mailangel
+    outmail
+    chkhbf
+    angel
+    gamblegive
+    chesscountry
+    tunepasswd
+    buildir
+    xchatd
+    uhash_loader
+    timecap_buildref
+    showuser
+    removebm
+    redir
+    permreport
+    setrole
+    update_online
+    munin
+    useractive_munin
+    shmctl
+    bbsmail
+    )
+
+set(CPP_WITH_UTIL
+    mergedir2
+    buildir2
+    )
+
+set(CPROG_WITHOUT_UTIL
+    showboard
+    bbsrf
+    initbbs
+    userlist
+    merge_board
+    bbsctl
+    )
+
+set(COPY_FILES
+    backpasswd.sh
+    mailog.sh
+    openticket.sh
+    topsong.sh
+    weather.sh
+    weather.perl
+    toplazyBM.sh
+    dailybackup.pl
+    tarqueue.pl
+    waterball.pl
+    filtermail.pl
+    getbackup.pl
+    rebuildaloha.pl
+    timecap_expire.sh
+    )
+
+add_custom_target(PROGS
+    DEPENDS ${CPROG_WITH_UTIL} ${CPROG_WITHOUT_UTIL} ${CPP_WITH_UTIL} ${COPY_FILES}
+    )
+
+file(COPY ${COPY_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+foreach(src ${UTILSRCS})
+    string(REGEX REPLACE "^util_" "" mbbsd_src ${src})
+    add_custom_command(OUTPUT ${src}
+        COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/mbbsd/${mbbsd_src} ${src}
+        )
+endforeach()
+
+set_source_files_properties(${UTILSRCS}
+    PROPERTIES
+    GENERATED TRUE
+    COMPILE_FLAGS -D_BBS_UTIL_C_
+)
+
+add_library(utilvar STATIC
+    ${UTILSRCS}
+    )
+
+foreach(prog ${CPROG_WITH_UTIL})
+    add_executable(${prog}
+        ${prog}.c
+        )
+    target_link_libraries(${prog} ${LDLIBS} utilvar)
+endforeach()
+
+foreach(prog ${CPP_WITH_UTIL})
+    add_executable(${prog}
+        ${prog}.cc
+        )
+    target_link_libraries(${prog} ${LDLIBS} utilvar)
+    set_source_files_properties(${prog}.cc
+        PROPERTIES
+        LANGUAGE CXX
+        )
+endforeach()
+
+foreach(prog ${CPROGR_WITHOUT_UTIL})
+    add_executable(${prog}
+        ${prog}.c
+        )
+endforeach()


### PR DESCRIPTION
This is to reflect the #34 by integrating CMakeLists.txt in mbbsd / common / util as well.

Tested in Mac (with ncurses installed with homebrew as static lib)
and Ubuntu 16.04 (by export CC=/usr/bin/clang and export CXX=/usr/bin/clang++)

The compiling / linking flags are the same as the original Makefile in these 2 platforms.

This PR is intended to used as discussion. I'll have the corresponding modification on #34 
after the discussion is finalized.
