### PR TITLE
Support with mongodb, googletest,  refactor with pttdb_main, comment, comment-reply.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mbbsd/mbbsd
 mbbsd/testmbbsd
 mbbsd/testsz
 mbbsd/vers.c
+/data_test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-SUBDIR=	common mbbsd util
+SUBDIR=	common mbbsd util tests
 
 .include <bsd.subdir.mk>
 
 .ORDER: all-common all-mbbsd
 .ORDER: all-common all-util
+.ORDER: all-mbbsd all-tests
+.ORDER: all-util all-tests

--- a/docs/mongodb.md
+++ b/docs/mongodb.md
@@ -1,0 +1,53 @@
+Mongodb
+===========
+
+目前使用 Mongodb 3.6.3 與 mongo-c-driver 1.9.3
+
+Setup (在 ubuntu 16.04 裡)
+-----
+1. sudo apt-get install pkg-config libssl-dev libsasl2-dev
+2. (libbson, should be in /usr/local/include and /usr/local/lib)
+```
+$ wget https://github.com/mongodb/libbson/releases/download/1.9.3/libbson-1.9.3.tar.gz
+$ cd libbson-1.9.3
+$ ./configure
+$ make
+$ sudo make install
+```
+3. (libmongoc, should be in /usr/local/include and /usr/local/lib)
+```
+$ wget https://github.com/mongodb/mongo-c-driver/releases/download/1.9.3/mongo-c-driver-1.9.3.tar.gz
+$ tar xzf mongo-c-driver-1.9.3.tar.gz
+$ cd mongo-c-driver-1.9.3
+$ ./configure --disable-automatic-init-and-cleanup
+$ make
+$ sudo make install
+```
+4. (MongoDB 3.6.3)
+```
+$ wget https://www.mongodb.org/static/pgp/server-3.6.asc?_ga=2.166282174.1683259271.1515240542-1836212786.1508650053&_gac=1.188702170.1514872595.Cj0KCQiA1afSBRD2ARIsAEvBsNnIeAsyFiSl05B2C2j8-2cOqs8Yza46dFczuxE8cmZuo0QcpaNaqxwaAk5JEALw_wcB -O mongo-key.gpg
+$ sudo apt-key add mongo-key.gpg
+$ echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+$ sudo apt-get update
+$ sudo apt-get install -y mongodb-org
+```
+5. (do tests/test_mbbsd/test_pttdb to pass test)
+```
+$ (uncomment MONGO_CLIENT_URL in pttbbs.conf)
+$ make GTEST_DIR=/usr/src/gtest
+$ ./tests/test_mbbsd/test_pttdb
+```
+
+Programming Style
+-----
+1. 盡量使用 pointer with BCON_NEW 來 initialize.
+2. pointer either 是 NULL or 是 BCON_NEW 的 initialized pointer. 使用 bson_safe_destroy 來安全的 free.
+3. `db_find_one`, `db_find`, `db_aggregate` 也會 intialize pointer. 使用 bson_safe_destroy 來安全的 free.
+4. `_serialize` 也會 initialize pointer. 使用 bson_safe_destroy 來安全的 free.
+5. mongo collections 會有相對應的 secondary-readable collections.
+
+Reference
+-----
+1. [libmongc](http://mongoc.org/libmongoc/current/index.html)
+2. [libbson](http://mongoc.org/libbson/current/index.html)
+3. [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/)

--- a/docs/pttdb.md
+++ b/docs/pttdb.md
@@ -1,0 +1,51 @@
+pttdb
+===========
+
+pttdb 嘗試使用 mongodb 做為 horizontally-scalable 的 db.
+目的是希望能夠將目前 main / comment / comment-reply 放在同一個 file 的方式.
+refactor 成 main-content, comment, comment-reply 分開儲存的方式.
+讓 ptt 可以容易 horizontally-scalable.
+
+
+Design
+========
+
+Main
+-----
+1. 容許 multi-line.
+2. 有一個 main-header. 儲存 main 的 meta-data.
+3. 有多個 contentBlock. 儲存 main-content.
+4. ContentBlock 有自己的 content_id.
+5. 在 create 時:
+    1. 先 create main-header-id.
+    2. 將 content-block insert 進去.
+    3. 將 main-header db-update. 並設定成 alive.
+6. 在 update 時 (預期大約是 create 的 1%):
+    1. 將新的 content-block insert 進 db.
+    2. 將 main-header 的 content-id 設定成新的 content-id.
+7. 在 read 時:
+    1. 根據需要的 offset 和 size. 讀 -2n-size ~ 3n-size 和相對應的 blocks.
+    2. 如果往上只剩 < -n-size => 再根據現在 offset 和 size. 重新要求 -2n-size ~ 3n-size
+    3. 如果往下只剩 < n-size => 再根據現在 offset 和 size. 重新要求 -2n-size ~ 3n-size
+
+ContentBlock
+-----
+1. buffer default 是 NULL pointer. 使用 init_content_block_buf_block 來 init buffer. 使用 destroy_content_block 來 free buffer.
+2. 可使用 associate_content_block 來 associate 既有的 buffer. 使用 dissociate_content_block 來重新設定為 NULL (不會 free buffer).
+3. 可使用 dynamic_read_content_blocks 來將連續的 content_block 在 read content 時 assign 到連續的 buffer 裡.
+
+Comment
+-----
+1. buffer default 是 NULL pointer. 使用 init_comment_buf 來 init buffer. 使用 destroy_comment 來 free buffer.
+2. 可使用 associate_comment 來 associate 既有的 buffer. 使用 dissociate_comment 來重新設定為 NULL (不會 free buffer).
+3. 單一 line.
+4. 不容許 update.
+5. 可以 delete.
+
+CommentReply
+-----
+1. buffer default 是 NULL pointer. 使用 init_comment_reply_buf 來 init buffer. 使用 destroy_comment_reply 來 free buffer.
+2. 可使用 associate_comment_reply 來 associate 既有的 buffer. 使用 dissociate_comment_reply 來重新設定為 NULL (不會 free buffer).
+3. 容許 multi-line.
+4. 考量到效能. comment_reply_id 目前跟 comment_id 是一致的. (不用考慮 multi-comment-reply records 問題)
+5. 目前 update 是直接覆蓋舊的.

--- a/docs/unittest.md
+++ b/docs/unittest.md
@@ -1,0 +1,14 @@
+Unit-Test
+===========
+
+這個 unit-test 是 based on googletest. 在 ubuntu 裡使用 libgtest-dev.
+
+Setup (在 ubuntu 16.04 裡)
+-----
+1. `apt-get install -y libgtest-dev`
+
+2. 在 pttbbs 做 `make GTEST_DIR=/usr/src/gtest`
+
+3. mkdir -p data_test
+
+4. 執行相對應的 test (ex: tests/test_mbbsd/test_dummy)

--- a/include/pttdb.h
+++ b/include/pttdb.h
@@ -1,0 +1,293 @@
+/* $Id$ */
+#ifndef PTTDB_H
+#define PTTDB_H
+
+#include "ptterr.h"
+#include "util_db.h"
+
+#include "bbs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define UUIDLEN 64
+#define _UUIDLEN 48
+
+#define MAX_ORIGIN_LEN 20
+#define MAX_WEB_LINK_LEN 100                  // MAX_ORIGN_LEN + 8 + 12 + BOARDLEN + 1 + 23
+#define MAX_BUF_SIZE 8192
+#define MAX_BUF_BLOCK 8192
+#define MAX_BUF_COMMENT 256
+#define MAX_BUF_LINES 256
+
+#define N_GEN_UUID_WITH_DB 10
+
+// XXX hack for time64_t and UUID
+typedef long long int time64_t;
+typedef unsigned char UUID[UUIDLEN];
+typedef unsigned char _UUID[_UUIDLEN];
+
+enum CommentType {
+    COMMENT_TYPE_GOOD,
+    COMMENT_TYPE_BAD,
+    COMMENT_TYPE_ARROW,
+    COMMENT_TYPE_SIZE,
+
+    COMMENT_TYPE_FORWARD,                       // hack for forward
+    COMMENT_TYPE_OTHER,                         // hack for other
+
+    COMMENT_TYPE_N_TYPE,
+    COMMENT_TYPE_MAX     = COMMENT_TYPE_SIZE - 1,
+    COMMENT_TYPE_DEFAULT = COMMENT_TYPE_GOOD,
+};
+
+enum Karma {
+    KARMA_GOOD = 1,
+    KARMA_BAD = -1,
+    KARMA_ARROW = 0,
+};
+
+enum LiveStatus {
+    LIVE_STATUS_ALIVE,
+    LIVE_STATUS_DELETED,
+};
+
+enum LineType {
+    LINE_TYPE_MAIN,
+    LINE_TYPE_COMMENT,
+    LINE_TYPE_COMMENT_REPLY,
+};
+
+enum ReadCommentsOpType {
+    READ_COMMENTS_OP_TYPE_LT,
+    READ_COMMENTS_OP_TYPE_LTE,
+    READ_COMMENTS_OP_TYPE_GT,
+    READ_COMMENTS_OP_TYPE_GTE,
+};
+
+extern enum Karma KARMA_BY_COMMENT_TYPE[COMMENT_TYPE_N_TYPE];
+
+/**********
+ * Main
+ * XXX always update main-content first, and then update main-header.
+ **********/
+typedef struct MainHeader {
+    unsigned int version;                            // version
+
+    UUID the_id;                                     // main id
+    UUID content_id;                                 // corresponding content-id
+    UUID update_content_id;                          // updating content-id, not effective if content_id == update_content_id
+    aidu_t aid;                                      // aid
+
+    enum LiveStatus status;                          // status of the main.
+    char status_updater[IDLEN + 1];                  // last user updating the status
+    char status_update_ip[IPV4LEN + 1];              // last ip updating the status
+
+    char board[IDLEN + 1];                           // board-id
+    char title[TTLEN + 1];                           // title
+
+    char poster[IDLEN + 1];                          // creater
+    char ip[IPV4LEN + 1];                            // create-ip
+    time64_t create_milli_timestamp;                 // create-time
+    char updater[IDLEN + 1];                         // last updater
+    char update_ip[IPV4LEN + 1];                     // last update-ip
+    time64_t update_milli_timestamp;                 // last update-time
+
+    char origin[MAX_ORIGIN_LEN + 1];                 // origin
+    char web_link[MAX_WEB_LINK_LEN + 1];                 // web-link
+
+    int reset_karma;                                 // reset-karma.
+
+    int n_total_line;                                // total-line
+    int n_total_block;                               // total-block
+    int len_total;                                   // total-size
+} MainHeader;
+
+/**********
+ * ContentBlock
+ **********/
+typedef struct ContentBlock {
+    UUID the_id;                                     // content-id
+    UUID ref_id;                                     // corresponding ref-id
+
+    int block_id;                                    // corresponding block-id
+
+    int len_block;                                   // size of this block.
+    int n_line;                                      // n-line of this block.
+
+    int max_buf_len;                                 // max buf len (not in db)
+    char *buf_block;                                 // buf
+} ContentBlock;
+
+/**********
+ * Comments
+ **********/
+typedef struct Comment {
+    unsigned int version;                            // version
+
+    UUID the_id;                                     // comment-id
+    UUID main_id;                                    // corresponding main-id
+
+    enum LiveStatus status;                          // status
+    char status_updater[IDLEN + 1];                  // last user updaing the status
+    char status_update_ip[IPV4LEN + 1];              // last ip updating the status
+
+    enum CommentType comment_type;                   // comment-type.
+    enum Karma karma;                                // karma
+
+    char poster[IDLEN + 1];                          // creater
+    char ip[IPV4LEN + 1];                            // create-ip
+    time64_t create_milli_timestamp;                 // create-time
+    char updater[IDLEN + 1];                         // last updater
+    char update_ip[IPV4LEN + 1];                     // last update-ip
+    time64_t update_milli_timestamp;                 // last update-time
+
+    int max_buf_len;                                 // max buf len
+    int len;                                         // size
+    char *buf;                                       // buf    
+} Comment;
+
+/**********
+ * CommentReply
+ * XXX always update comment-reply-content first, and then update comment-reply-header.
+ **********/
+typedef struct CommentReply {
+    unsigned int version;                           // version
+
+    UUID the_id;                                     // comment-reply-id
+
+    UUID comment_id;                                 // corresponding comment-id
+    UUID main_id;                                    // corresponding main-id
+
+    enum LiveStatus status;                          // status
+    char status_updater[IDLEN + 1];                  // last user updating status
+    char status_update_ip[IPV4LEN + 1];              // last ip updating the status
+
+    char poster[IDLEN + 1];                          // creater
+    char ip[IPV4LEN + 1];                            // create-ip
+    time64_t create_milli_timestamp;                 // create-time
+    char updater[IDLEN + 1];                         // last updater
+    char update_ip[IPV4LEN + 1];                     // last update-ip
+    time64_t update_milli_timestamp;                 // last update-time
+
+    int max_buf_len;                                 // max_buf_len
+    int len;                                         // size
+    int n_line;                                      // n-line
+    char *buf;
+} CommentReply;
+
+/**********
+ * Milli-timestamp
+ **********/
+Err get_milli_timestamp(time64_t *milli_timestamp);
+
+/**********
+ * UUID
+ **********/
+Err gen_uuid(UUID uuid);
+Err gen_uuid_with_db(int collection, UUID uuid);
+Err gen_content_uuid_with_db(int collection, UUID uuid);
+
+Err uuid_to_milli_timestamp(UUID uuid, time64_t *milli_timestamp);
+
+/**********
+ * Post
+ **********/
+Err n_line_post(UUID main_id, int *n_line);
+
+/*
+Err get_content_by_main(UUID main_id, int offset_line, char *buf, int max_n_buf, int max_n_line, int *n_buf, int *n_line, LineInfo *start_line_info, LineInfo *end_line_info);
+Err scroll_up_by_line_info(LineInfo *orig_start_line_info, char *buf, int max_n_buf, int max_n_line, int *n_buf, int *n_line, LineInfo *new_start_line_info, LineInfo *new_end_line_info);
+Err scroll_down_by_line_info(LineInfo *orig_end_line_info, char *buf, int max_n_buf, int max_n_line, int *n_buf, int *n_line, LineInfo *new_start_line_info, LineInfo *new_end_line_info);
+
+Err dynamic_read_comment_and_comment_reply_by_main(UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, char *buf, int max_n_buf, int max_n_line, Comment *comments, int max_n_comments, CommentReply *comment_replys, int *n_comments, int *n_comment_replys);
+*/
+
+/**********
+ * Main
+ **********/
+Err create_main_from_fd(aidu_t aid, char *board, char *title, char *poster, char *ip, char *origin, char *web_link, int len, int fd_content, UUID main_id, UUID content_id);
+
+Err len_main(UUID main_id, int *len);
+Err len_main_by_aid(aidu_t aid, int *len);
+
+Err n_line_main(UUID main_id, int *n_line);
+Err n_line_main_by_aid(aidu_t aid, int *n_line);
+
+Err read_main_header(UUID main_id, MainHeader *main_header);
+Err read_main_header_by_aid(aidu_t aid, MainHeader *main_header);
+
+Err delete_main(UUID main_id, char *updater, char *ip);
+Err delete_main_by_aid(aidu_t aid, char *updater, char *ip);
+
+Err update_main_from_fd(UUID main_id, char *updater, char *update_ip, int len, int fd_content, UUID content_id);
+
+/**********
+ * ContentBlock
+ **********/
+Err split_contents(char *buf, int bytes, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, int *n_line, int *n_block);
+Err split_contents_from_fd(int fd_content, int len, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, int *n_line, int *n_block);
+
+Err delete_content(UUID content_id, enum MongoDBId mongo_db_id);
+
+Err reset_content_block(ContentBlock *content_block, UUID ref_id, UUID content_id, int block_id);
+Err reset_content_block_buf_block(ContentBlock *content_block);
+
+Err init_content_block_with_buf_block(ContentBlock *content_block, UUID ref_id, UUID content_id, int block_id);
+Err init_content_block_buf_block(ContentBlock *content_block);
+Err destroy_content_block(ContentBlock *content_block);
+
+Err associate_content_block(ContentBlock *content_block, char *buf_block, int max_buf_len);
+Err dissociate_content_block(ContentBlock *content_block);
+
+Err save_content_block(ContentBlock *content_block, enum MongoDBId mongo_db_id);
+Err read_content_block(UUID content_id, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_block);
+Err read_content_blocks(UUID content_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_blocks, int *n_block, int *len);
+Err read_content_blocks_by_ref(UUID ref_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_blocks, int *n_block, int *len);
+Err dynamic_read_content_blocks(UUID content_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, char *buf, int max_buf_size, ContentBlock *content_blocks, int *n_block, int *len);
+Err dynamic_read_content_blocks_by_ref(UUID ref_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, char *buf, int max_buf_size, ContentBlock *content_blocks, int *n_block, int *len);
+
+/**********
+ * Comments
+ **********/
+
+Err create_comment(UUID main_id, char *poster, char *ip, int len, char *content, enum CommentType comment_type, UUID comment_id);
+
+Err read_comment(UUID comment_id, Comment *comment);
+
+Err delete_comment(UUID comment_id, char *updater, char *ip);
+
+Err get_comment_info_by_main(UUID main_id, int *n_total_comments, int *total_len);
+Err get_comment_count_by_main(UUID main_id, int *count);
+
+Err init_comment_buf(Comment *comment);
+Err destroy_comment(Comment *comment);
+
+Err associate_comment(Comment *comment, char *buf, int max_buf_len);
+Err dissociate_comment(Comment *comment);
+Err read_comments_by_main(UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, Comment *comments, int *n_read_comments, int *len);
+
+/**********
+ * CommentReply
+ **********/
+
+Err create_comment_reply(UUID main_id, UUID comment_id, char *poster, char *ip, int len, char *content, UUID comment_reply_id);
+
+Err read_comment_reply(UUID comment_reply_id, CommentReply *comment_reply);
+
+Err delete_comment_reply(UUID comment_reply_id, char *updater, char *ip);
+
+Err init_comment_reply_buf(CommentReply *comment_reply);
+Err destroy_comment_reply(CommentReply *comment_reply);
+
+Err get_comment_reply_info_by_main(UUID main_id, int *n_comment_reply, int *n_line, int *total_len);
+
+Err associate_comment_reply(CommentReply *comment_reply, char *buf, int max_buf_len);
+Err dissociate_comment_reply(CommentReply *comment_reply);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PTTDB_H */

--- a/include/pttdb_internal.h
+++ b/include/pttdb_internal.h
@@ -1,0 +1,86 @@
+/* $Id$ */
+#ifndef PTTDB_INTERNAL_H
+#define PTTDB_INTERNAL_H
+
+#include "ptterr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <sys/time.h>
+#include <resolv.h>
+
+/**********
+ * UUID
+ **********/
+Err _serialize_uuid_bson(UUID uuid, bson_t **uuid_bson);
+Err _serialize_content_uuid_bson(UUID uuid, int block_id, bson_t **uuid_bson);
+
+/**********
+ * Main
+ **********/
+
+Err _serialize_main_bson(MainHeader *main_header, bson_t **main_bson);
+Err _deserialize_main_bson(bson_t *main_bson, MainHeader *main_header);
+Err _serialize_update_main_bson(UUID content_id, char *updater, char *update_ip, time64_t update_milli_timestamp, int n_total_line, int n_total_block, int len_total, bson_t **main_bson);
+
+/**********
+ * ContentBlock
+ **********/
+Err _split_contents_core(char *buf, int bytes, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, int *n_line, int *n_block, char *line, int *bytes_in_line, ContentBlock *content_block);
+
+Err _split_contents_core_one_line(char *line, int bytes_in_line, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, ContentBlock *content_block, int *n_line, int *n_block);
+
+Err _split_contents_deal_with_last_line_block(int bytes_in_line, char *line, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, ContentBlock *content_block, int *n_line, int *n_block);
+
+Err _read_content_blocks_core(bson_t *key, int max_n_block, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_blocks, int *n_block, int *len);
+Err _dynamic_read_content_blocks_core(bson_t *key, int max_n_block, int block_id, enum MongoDBId mongo_db_id, char *buf, int max_buf_size, ContentBlock *content_blocks, int *n_block, int *len);
+Err _read_content_blocks_get_db_results(bson_t **db_results, bson_t *key, int max_n_block, int block_id, enum MongoDBId mongo_db_id, int *n_block);
+
+Err _form_b_array_block_ids(int block_id, int max_n_block, bson_t *b);
+Err _sort_by_block_id(bson_t **db_results, int n_block);
+int _cmp_sort_by_block_id(const void *a, const void *b);
+Err _ensure_block_ids(bson_t **db_results, int start_block_id, int n_block);
+
+Err _serialize_content_block_bson(ContentBlock *content_block, bson_t **content_block_bson);
+Err _deserialize_content_block_bson(bson_t *content_block_bson, ContentBlock *content_block);
+
+/**********
+ * Comment
+ **********/
+
+Err _serialize_comment_bson(Comment *comment, bson_t **comment_bson);
+Err _deserialize_comment_bson(bson_t *comment_bson, Comment *comment);
+Err _get_comment_info_by_main_deal_with_result(bson_t *result, int n_result, int *n_total_comments, int *total_len);
+Err _read_comments_get_db_results(bson_t **db_results, UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments);
+Err _read_comments_get_db_results_same_create_milli_timestamp(bson_t **db_results, UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments);
+Err _read_comments_get_db_results_diff_create_milli_timestamp(bson_t **db_results, UUID main_id, time64_t create_milli_timestamp, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments);
+Err _read_comments_get_db_results_core(bson_t **db_results, bson_t *key, bson_t *sort, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments);
+Err _ensure_db_results_order(bson_t **db_results, int n_results, enum ReadCommentsOpType op_type);
+Err _sort_db_results_order(bson_t **db_results, int n_results, enum ReadCommentsOpType op_type);
+int _cmp_ascending(const void *a, const void *b);
+int _cmp_descending(const void *a, const void *b);
+Err _reverse_db_results(bson_t **db_results, int n_results);
+
+/**********
+ * CommentReply
+ **********/
+
+Err _serialize_comment_reply_bson(CommentReply *comment_reply, bson_t **comment_reply_bson);
+Err _deserialize_comment_reply_bson(bson_t *comment_reply_bson, CommentReply *comment_reply);
+Err _deserialize_comment_reply_bson_with_buf(bson_t *comment_reply_bson, CommentReply *comment_reply);
+Err _get_comment_reply_info_by_main_deal_with_result(bson_t *result, int n_result, int *n_comment_reply, int *n_line, int *total_len);
+
+/**********
+ * Misc
+ **********/
+
+Err get_line_from_buf(char *p_buf, int offset_buf, int bytes, char *p_line, int offset_line, int *bytes_in_new_line);
+Err pttdb_count_lines(char *content, int len, int *n_line);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PTTDB_INTERNAL_H */

--- a/include/ptterr.h
+++ b/include/ptterr.h
@@ -1,0 +1,24 @@
+/* $Id$ */
+#ifndef PTTERR_H
+#define PTTERR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef char Err;
+
+#define S_OK 0
+#define S_ERR -1
+#define S_ERR_MALLOC -2
+#define S_ERR_ALREADY_EXISTS -3
+#define S_ERR_NOT_EXISTS -4
+#define S_ERR_FOUND_MULTI -5
+#define S_ERR_BUFFER_LEN -6
+#define S_ERR_INIT -7
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PTTERR_H */

--- a/include/util_db.h
+++ b/include/util_db.h
@@ -1,0 +1,76 @@
+/* $Id$ */
+#ifndef UTIL_DB_H
+#define UTIL_DB_H
+
+#include <mongoc.h>
+#include "ptterr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Mongo Post
+#define MONGO_MAIN_NAME "main"
+#define MONGO_MAIN_CONTENT_NAME "main_content"
+#define MONGO_COMMENT_NAME "comment"
+#define MONGO_COMMENT_REPLY_NAME "comment_reply"
+
+// Mongo Test
+#define MONGO_TEST_NAME "test"
+
+// Mongo the id
+#define MONGO_THE_ID "the_id"
+#define MONGO_BLOCK_ID "block_id"
+
+enum
+{
+    MONGO_POST_DBNAME,
+    MONGO_TEST_DBNAME,
+};
+
+enum MongoDBId {
+    MONGO_MAIN,
+    MONGO_MAIN_CONTENT,
+    MONGO_COMMENT,
+    MONGO_COMMENT_REPLY,
+
+    MONGO_TEST,
+
+    N_MONGO_COLLECTIONS,
+};
+
+// initialization / free
+Err init_mongo_global();
+Err free_mongo_global();
+Err init_mongo_collections(const char *db_name[]);
+Err free_mongo_collections();
+
+// db-ops
+Err db_set_if_not_exists(int collection, bson_t *key);
+Err db_update_one(int collection, bson_t *key, bson_t *val, bool is_upsert);
+Err db_remove(int collection, bson_t *key);
+Err db_count(int collection, bson_t *key, int *count);
+
+// XXX require bson_safe_destroy on results
+Err db_find_one(int collection, bson_t *key, bson_t *fields, bson_t **result);
+Err db_find(int collection, bson_t *key, bson_t *fields, bson_t *sort, int max_n_results, int *n_results, bson_t **results);
+Err db_aggregate(int collection, bson_t *pipeline, int max_n_results, bson_t **results, int *n_results);
+
+// bson-ops
+#define BCON_BINARY(bin, length) BCON_BIN(BSON_SUBTYPE_BINARY, bin, length)
+#define bson_append_bin(b, key, key_length, bin, length) bson_append_binary(b, key, key_length, BSON_SUBTYPE_BINARY, bin, length)
+
+Err bson_exists(bson_t *b, char *name, bool *is_exist);
+Err bson_get_value_int32(bson_t *b, char *name, int *value);
+Err bson_get_value_int64(bson_t *b, char *name, long int *value);
+Err bson_get_value_bin_not_initialized(bson_t *b, char *name, char **value, int *p_len);
+Err bson_get_value_bin(bson_t *b, char *name, int max_len, char *value, int *p_len);
+
+Err bson_safe_destroy(bson_t **b);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UTIL_DB_H */

--- a/include/util_db_internal.h
+++ b/include/util_db_internal.h
@@ -1,0 +1,23 @@
+/* $Id$ */
+#ifndef UTIL_DB_INTERNAL_H
+#define UTIL_DB_INTERNAL_H
+
+#include <mongoc.h>
+#include "ptterr.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**********
+ * Mongo
+ **********/
+
+// XXX NEVER USE UNLESS IN TEST
+Err _DB_FORCE_DROP_COLLECTION(int collection);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UTIL_DB_INTERNAL_H */

--- a/mbbsd/Makefile
+++ b/mbbsd/Makefile
@@ -59,6 +59,7 @@ USE_BBSLUA!=  	sh -c '${DEF_CMD}"USE_BBSLUA" ${BBSCONF} ${DEF_YES}'
 USE_PFTERM!=	sh -c '${DEF_CMD}"USE_PFTERM" ${BBSCONF} ${DEF_YES}'
 USE_NIOS!=	sh -c '${DEF_CMD}"USE_NIOS"   ${BBSCONF} ${DEF_YES}'
 USE_CONVERT!=	sh -c '${DEF_CMD}"CONVERT"    ${BBSCONF} ${DEF_YES}'
+MONGO_CLIENT_URL!=	sh -c '${DEF_CMD}"MONGO_CLIENT_URL" ${BBSCONF} ${DEF_YES}'
 
 .if $(USE_BBSLUA)
 .if $(OSTYPE)=="FreeBSD"
@@ -80,6 +81,16 @@ OBJS+=		pfterm.o
 OBJS+=		screen.o
 .endif
 
+.if $(MONGO_CLIENT_URL)
+MONGO_CFLAGS:=	-I/usr/local/include/libmongoc-1.0 -I/usr/local/include/libbson-1.0
+MONGO_LDFLAGS:=	-L/usr/local/lib
+MONGO_LIBS:=	-L/usr/local/lib -lmongoc-1.0 -lbson-1.0 -lresolv
+CFLAGS+=	${MONGO_CFLAGS}
+LDFLAGS+=	${MONGO_LDFLAGS}
+LDLIBS+=	${MONGO_LIBS}
+OBJS+=		pttdb.o pttdb_main.o pttdb_comment.o pttdb_comment_reply.o pttdb_content_block.o pttdb_misc.o util_db.o
+.endif # MONGO_CLIENT_URL
+
 #######################################################################
 # Make Rules
 #######################################################################
@@ -100,6 +111,7 @@ $(PROG): testsz $(OBJS)
 	@[ -z "$(USE_PFTERM)" ] || echo -n "+PFTERM "
 	@[ -z "$(USE_CONVERT)" ] || echo -n "+CONVERT "
 	@[ -z "$(USE_NIOS)" ] || echo -n "+NIOS "
+	@[ -z "$(MONGO_CLIENT_URL)" ] || echo -n "+MONGO_CLIENT_URL "
 	@printf "\033[m"
 	$(CC) vers.c -o $(PROG) $(OBJS) $(LDFLAGS) $(LDLIBS)
 

--- a/mbbsd/pttdb.c
+++ b/mbbsd/pttdb.c
@@ -1,0 +1,37 @@
+#include "pttdb.h"
+#include "pttdb_internal.h"
+
+/**
+ * @brief Get the lines of the post to be able to show the percentage.
+ * @details Get the lines of the post to be able to show the percentage.
+ *          XXX maybe we need to exclude n_line_comment_reply to simplify the indication of the line no.
+ *          XXX Simplification: We count only the lines of main the numbers of comments.
+ *                              It is with high probability that the users accept the modification.
+ * @param main_id main_id for the post
+ * @param n_line n_line (to-compute)
+ * @return Err
+ */
+
+Err
+n_line_post(UUID main_id, int *n_line) {
+    Err error_code = S_OK;
+    int the_line_main = 0;
+    int the_line_comments = 0;
+    int the_line_comment_reply = 0;
+    int n_comment_reply = 0;
+    int len_comment_reply = 0;
+
+    error_code = n_line_main(main_id, &the_line_main);
+    if (error_code) return error_code;
+
+    error_code = get_comment_count_by_main(main_id, &the_line_comments);
+    if (error_code) return error_code;
+
+    error_code = get_comment_reply_info_by_main(main_id, &n_comment_reply, &the_line_comment_reply, &len_comment_reply);
+    if (error_code) return error_code;
+
+    *n_line = the_line_main + the_line_comments + the_line_comment_reply;
+
+    return S_OK;
+}
+

--- a/mbbsd/pttdb_comment.c
+++ b/mbbsd/pttdb_comment.c
@@ -1,0 +1,684 @@
+#include "pttdb.h"
+#include "pttdb_internal.h"
+
+enum Karma KARMA_BY_COMMENT_TYPE[] = {
+    KARMA_GOOD,
+    KARMA_BAD,
+    KARMA_ARROW,
+    0,
+    0,                   // forward
+    0,                   // other
+};
+
+char *_read_comments_op_type[] = {
+    "$lt",
+    "$lte",
+    "$gt",
+    "$gte",
+};
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_id [description]
+ * @param poster [description]
+ * @param ip [description]
+ * @param len [description]
+ * @param content [description]
+ * @param comment_id [description]
+ */
+Err
+create_comment(UUID main_id, char *poster, char *ip, int len, char *content, enum CommentType comment_type, UUID comment_id)
+{
+    Err error_code = S_OK;
+
+    time64_t create_milli_timestamp;
+
+    // use associate to associate content directly
+    Comment comment = {};
+    associate_comment(&comment, content, len);
+    comment.len = len;
+
+    error_code = get_milli_timestamp(&create_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = gen_uuid_with_db(MONGO_COMMENT, comment_id);
+    if (error_code) return error_code;
+
+    // comment
+    memcpy(comment.the_id, comment_id, sizeof(UUID));
+    memcpy(comment.main_id, main_id, sizeof(UUID));
+    comment.status = LIVE_STATUS_ALIVE;
+    strcpy(comment.status_updater, poster);
+    strcpy(comment.status_update_ip, ip);
+
+    comment.comment_type = comment_type;
+    comment.karma = KARMA_BY_COMMENT_TYPE[comment_type];
+
+    strcpy(comment.poster, poster);
+    strcpy(comment.ip, ip);
+    comment.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment.updater, poster);
+    strcpy(comment.update_ip, ip);
+    comment.update_milli_timestamp = create_milli_timestamp;
+
+    // db-comment
+    bson_t *comment_id_bson = NULL;
+    bson_t *comment_bson = NULL;
+
+    error_code = _serialize_comment_bson(&comment, &comment_bson);
+    if (!error_code) {
+        error_code = _serialize_uuid_bson(comment_id, &comment_id_bson);
+    }
+
+    if (!error_code) {
+        error_code = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+    }
+
+    bson_safe_destroy(&comment_bson);
+    bson_safe_destroy(&comment_id_bson);
+    dissociate_comment(&comment);
+
+    return error_code;
+}
+
+Err
+read_comment(UUID comment_id, Comment *comment)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+                      "the_id", BCON_BINARY(comment_id, UUIDLEN)
+                  );
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_COMMENT, key, NULL, &db_result);
+
+    if (!error_code) {
+        error_code = _deserialize_comment_bson(db_result, comment);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&db_result);
+    return error_code;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_id [description]
+ * @param updater [description]
+ * @param char [description]
+ * @return [description]
+ */
+Err
+delete_comment(UUID comment_id, char *updater, char *ip) {
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+        "the_id", BCON_BINARY(comment_id, UUIDLEN)
+    );
+
+    bson_t *val = BCON_NEW(
+        "status_updater", BCON_BINARY((unsigned char *)updater, IDLEN),
+        "status", BCON_INT32((int)LIVE_STATUS_DELETED),
+        "status_update_ip", BCON_BINARY((unsigned char *)ip, IPV4LEN)
+    );
+
+    error_code = db_update_one(MONGO_COMMENT, key, val, true);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+    return error_code;
+}
+
+Err
+get_comment_info_by_main(UUID main_id, int *n_total_comments, int *total_len)
+{
+    Err error_code = S_OK;
+    bson_t *pipeline = BCON_NEW(
+        "pipeline", "[",
+            "{",
+                "$match", "{",
+                    "main_id", BCON_BINARY(main_id, UUIDLEN),
+                    "status", BCON_INT32((int)LIVE_STATUS_ALIVE),
+                "}",
+            "}",
+            "{",
+                "$group", "{",
+                    "_id", BCON_NULL,
+                    "count", "{",
+                        "$sum", BCON_INT32(1),
+                    "}",
+                    "len", "{",
+                        "$sum", "$len",
+                    "}",
+                "}",
+            "}",
+        "]"
+    );
+
+    if (pipeline == NULL) error_code = S_ERR;
+
+    bson_t *result = NULL;
+
+    int n_result = 0;
+    if (!error_code) {
+        error_code = db_aggregate(MONGO_COMMENT, pipeline, 1, &result, &n_result);
+    }
+
+    if (!error_code) {
+        error_code = _get_comment_info_by_main_deal_with_result(result, n_result, n_total_comments, total_len);
+    }
+
+    bson_safe_destroy(&result);
+    bson_safe_destroy(&pipeline);
+
+    return error_code;
+}
+
+Err
+get_comment_count_by_main(UUID main_id, int *count)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "main_id", BCON_BINARY(main_id, UUIDLEN),
+        "status", BCON_INT32((int)LIVE_STATUS_ALIVE)
+    );
+
+    error_code = db_count(MONGO_COMMENT, key, count);
+
+    bson_safe_destroy(&key);
+
+    return error_code;
+}
+
+Err
+init_comment_buf(Comment *comment)
+{
+    if (comment->buf != NULL) return S_OK;
+
+    comment->buf = malloc(MAX_BUF_COMMENT);
+    if (comment->buf == NULL) return S_ERR;
+
+    comment->max_buf_len = MAX_BUF_COMMENT;
+    bzero(comment->buf, MAX_BUF_COMMENT);
+    comment->len = 0;
+
+    return S_OK;
+}
+
+Err
+destroy_comment(Comment *comment)
+{
+    if (comment->buf == NULL) return S_OK;
+
+    free(comment->buf);
+    comment->buf = NULL;
+    comment->max_buf_len = 0;
+    comment->len = 0;
+
+    return S_OK;
+}
+
+Err
+associate_comment(Comment *comment, char *buf, int max_buf_len)
+{
+    if (comment->buf != NULL) return S_ERR;
+
+    comment->buf = buf;
+    comment->max_buf_len = max_buf_len;
+    comment->len = 0;
+
+    return S_OK;
+}
+
+Err
+dissociate_comment(Comment *comment)
+{
+    if (comment->buf == NULL) return S_OK;
+
+    comment->buf = NULL;
+    comment->max_buf_len = 0;
+    comment->len = 0;
+
+    return S_OK;
+}
+
+Err
+read_comments_by_main(UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, Comment *comments, int *n_read_comments, int *len)
+{
+
+    Err error_code = S_OK;
+
+    // init db-results
+    bson_t **db_results = malloc(sizeof(bson_t *) * max_n_comments);
+    if (db_results == NULL) return S_ERR_INIT;
+    bzero(db_results, sizeof(bson_t *) * max_n_comments);
+
+    error_code = _read_comments_get_db_results(db_results, main_id, create_milli_timestamp, poster, op_type, max_n_comments, mongo_db_id, n_read_comments);
+
+    fprintf(stderr, "pttdb_comment.read_comments_by_main: after _read_comments_get_db_results: e: %d n_read_comments: %d\n", error_code, *n_read_comments);
+
+    int tmp_n_read_comments = *n_read_comments;
+    bson_t **p_db_results = db_results;
+    Comment *p_comments = comments;
+
+    int tmp_len = 0;
+    if (!error_code) {
+        for (int i = 0; i < tmp_n_read_comments; i++) {
+            error_code = _deserialize_comment_bson(*p_db_results, p_comments);
+
+            tmp_len += p_comments->len;
+            p_db_results++;
+            p_comments++;
+
+            if (error_code) {
+                *n_read_comments = i;
+                break;
+            }
+        }
+    }
+
+    *len = tmp_len;
+
+    // free
+    p_db_results = db_results;
+    for (int i = 0; i < tmp_n_read_comments; i++) {
+        bson_safe_destroy(p_db_results);
+        p_db_results++;
+    }
+    free(db_results);
+
+    return error_code;
+}
+
+Err
+_get_comment_info_by_main_deal_with_result(bson_t *result, int n_result, int *n_total_comments, int *total_len)
+{
+    if (!n_result) {
+        *n_total_comments = 0;
+        *total_len = 0;
+        return S_OK;
+    }
+
+    Err error_code = S_OK;
+
+    error_code = bson_get_value_int32(result, "count", n_total_comments);
+
+    if (!error_code) {
+        error_code = bson_get_value_int32(result, "len", total_len);
+    }
+
+    return error_code;
+}
+
+Err
+_read_comments_get_db_results(bson_t **db_results, UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments)
+{
+    Err error_code = S_OK;
+
+    int n_comments_same_create_milli_timestamp = 0;
+
+    bson_t **p_db_results = db_results;
+    error_code = _read_comments_get_db_results_same_create_milli_timestamp(p_db_results, main_id, create_milli_timestamp, poster, op_type, max_n_comments, mongo_db_id, &n_comments_same_create_milli_timestamp);
+    if(error_code == S_ERR_NOT_EXISTS) error_code = S_OK;
+
+    if(!error_code) {
+        p_db_results += n_comments_same_create_milli_timestamp;
+        max_n_comments -= n_comments_same_create_milli_timestamp;
+    }
+
+    int n_comments_diff_create_milli_timestamp = 0;
+    if(!error_code && max_n_comments > 0) {
+        error_code = _read_comments_get_db_results_diff_create_milli_timestamp(p_db_results, main_id, create_milli_timestamp, op_type, max_n_comments, mongo_db_id, &n_comments_diff_create_milli_timestamp);
+        if(error_code == S_ERR_NOT_EXISTS) error_code = S_OK;
+    }
+
+    *n_comments = n_comments_same_create_milli_timestamp + n_comments_diff_create_milli_timestamp;
+
+    if(!error_code && (op_type == READ_COMMENTS_OP_TYPE_LT || op_type == READ_COMMENTS_OP_TYPE_LTE)) {
+        error_code = _reverse_db_results(db_results, *n_comments);
+    }
+
+    return error_code;
+}
+
+
+Err
+_read_comments_get_db_results_same_create_milli_timestamp(bson_t **db_results, UUID main_id, time64_t create_milli_timestamp, char *poster, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments)
+{
+    Err error_code = S_OK;
+    int order = (op_type == READ_COMMENTS_OP_TYPE_GT || op_type == READ_COMMENTS_OP_TYPE_GTE) ? 1 : -1;
+
+    // get same create_milli_timestamp but not same poster
+    bson_t *key = BCON_NEW(
+        "main_id", BCON_BINARY(main_id, UUIDLEN),
+        "status", BCON_INT32(LIVE_STATUS_ALIVE),
+        "create_milli_timestamp", BCON_INT64(create_milli_timestamp),
+        "poster", "{",
+            _read_comments_op_type[op_type], BCON_BINARY((unsigned char *)poster, IDLEN),
+        "}"
+    );
+
+    if (key == NULL) error_code = S_ERR;
+
+    bson_t *sort = BCON_NEW(
+        "poster", BCON_INT32(order)
+    );
+    
+    if(sort == NULL) error_code = S_ERR;
+
+    if(!error_code) {
+        error_code = _read_comments_get_db_results_core(db_results, key, sort, op_type, max_n_comments, mongo_db_id, n_comments);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&sort);
+
+    return error_code;
+}
+
+Err
+_read_comments_get_db_results_diff_create_milli_timestamp(bson_t **db_results, UUID main_id, time64_t create_milli_timestamp, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments)
+{
+    Err error_code = S_OK;
+    int order = (op_type == READ_COMMENTS_OP_TYPE_GT || op_type == READ_COMMENTS_OP_TYPE_GTE) ? 1 : -1;
+    if(op_type == READ_COMMENTS_OP_TYPE_GTE) {
+        op_type = READ_COMMENTS_OP_TYPE_GT;
+    }
+
+    if(op_type == READ_COMMENTS_OP_TYPE_LTE) {
+        op_type = READ_COMMENTS_OP_TYPE_LT;
+    }
+
+    // get same create_milli_timestamp but not same poster
+    bson_t *key = BCON_NEW(
+        "main_id", BCON_BINARY(main_id, UUIDLEN),
+        "status", BCON_INT32(LIVE_STATUS_ALIVE),
+        "create_milli_timestamp", "{",
+            _read_comments_op_type[op_type], BCON_INT64(create_milli_timestamp),
+        "}"
+    );
+
+    if (key == NULL) error_code = S_ERR;
+
+    bson_t *sort = BCON_NEW(
+        "create_milli_timestamp", BCON_INT32(order),
+        "poster", BCON_INT32(order)
+    );
+    
+    if(sort == NULL) error_code = S_ERR;
+
+    if(!error_code) {
+        error_code = _read_comments_get_db_results_core(db_results, key, sort, op_type, max_n_comments, mongo_db_id, n_comments);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&sort);
+
+    return error_code;
+}
+
+Err
+_read_comments_get_db_results_core(bson_t **db_results, bson_t *key, bson_t *sort, enum ReadCommentsOpType op_type, int max_n_comments, enum MongoDBId mongo_db_id, int *n_comments)
+{
+    Err error_code = db_find(mongo_db_id, key, NULL, sort, max_n_comments, n_comments, db_results);
+
+    int tmp_n_comments = *n_comments;
+
+    Err error_code_ensure_order = S_OK;
+    if (!error_code) {
+        error_code_ensure_order = _ensure_db_results_order(db_results, tmp_n_comments, op_type);
+    }
+
+    if (!error_code && error_code_ensure_order) {
+        error_code = _sort_db_results_order(db_results, tmp_n_comments, op_type);
+    }
+
+    return error_code;
+}
+
+Err
+_ensure_db_results_order(bson_t **db_results, int n_results, enum ReadCommentsOpType op_type)
+{
+    Err error_code = S_OK;
+    bson_t **p_db_results = db_results;
+    bson_t **p_next_db_results = db_results + 1;
+    int cmp = 0;
+    int (*_cmp)(const void *a, const void *b) = (op_type == READ_COMMENTS_OP_TYPE_LT || op_type == READ_COMMENTS_OP_TYPE_LTE) ? _cmp_descending : _cmp_ascending;
+
+    for (int i = 0; i < n_results - 1; i++, p_db_results++, p_next_db_results++) {
+        cmp = _cmp(p_db_results, p_next_db_results);
+        if (cmp > 0) {
+            error_code = S_ERR;
+            break;
+        }
+    }
+
+    return error_code;
+}
+
+Err
+_sort_db_results_order(bson_t **db_results, int n_results, enum ReadCommentsOpType op_type)
+{
+    int (*_cmp)(const void *a, const void *b) = (op_type == READ_COMMENTS_OP_TYPE_LT || op_type == READ_COMMENTS_OP_TYPE_LTE) ? _cmp_descending : _cmp_ascending;
+
+    qsort(db_results, n_results, sizeof(bson_t *), _cmp);
+
+    return S_OK;
+}
+
+int
+_cmp_ascending(const void *a, const void *b)
+{
+    bson_t **tmp_tmp_a = (bson_t **)a;
+    bson_t *tmp_a = *tmp_tmp_a;
+    bson_t **tmp_tmp_b = (bson_t **)b;
+    bson_t *tmp_b = *tmp_tmp_b;
+
+    time64_t create_milli_timestamp_a = 0;
+    time64_t create_milli_timestamp_b = 0;
+
+    char poster_a[IDLEN + 1] = {};
+    char poster_b[IDLEN + 1] = {};
+
+    Err error_code;
+    error_code = bson_get_value_int64(tmp_a, "create_milli_timestamp", (long *)&create_milli_timestamp_a);
+    if (error_code) create_milli_timestamp_a = -1;
+
+    error_code = bson_get_value_int64(tmp_b, "create_milli_timestamp", (long *)&create_milli_timestamp_b);
+    if (error_code) create_milli_timestamp_b = -1;
+
+    if (create_milli_timestamp_a != create_milli_timestamp_b) {
+        return create_milli_timestamp_a - create_milli_timestamp_b;
+    }
+
+    int len;
+    error_code = bson_get_value_bin(tmp_a, "poster", IDLEN, poster_a, &len);
+    if (error_code) bzero(poster_a, IDLEN + 1);
+
+    error_code = bson_get_value_bin(tmp_b, "poster", IDLEN, poster_b, &len);
+    if (error_code) bzero(poster_b, IDLEN + 1);
+
+    return strncmp(poster_a, poster_b, IDLEN);
+}
+
+int
+_cmp_descending(const void *a, const void *b)
+{
+    bson_t **tmp_tmp_a = (bson_t **)a;
+    bson_t *tmp_a = *tmp_tmp_a;
+    bson_t **tmp_tmp_b = (bson_t **)b;
+    bson_t *tmp_b = *tmp_tmp_b;
+
+    time64_t create_milli_timestamp_a = 0;
+    time64_t create_milli_timestamp_b = 0;
+
+    char poster_a[IDLEN + 1] = {};
+    char poster_b[IDLEN + 1] = {};
+
+    Err error_code;
+    error_code = bson_get_value_int64(tmp_a, "create_milli_timestamp", (long *)&create_milli_timestamp_a);
+    if (error_code) create_milli_timestamp_a = -1;
+
+    error_code = bson_get_value_int64(tmp_b, "create_milli_timestamp", (long *)&create_milli_timestamp_b);
+    if (error_code) create_milli_timestamp_b = -1;
+
+    if (create_milli_timestamp_a != create_milli_timestamp_b) {
+        return create_milli_timestamp_b - create_milli_timestamp_a;
+    }
+
+    int len;
+    error_code = bson_get_value_bin(tmp_a, "poster", IDLEN, poster_a, &len);
+    if (error_code) bzero(poster_a, IDLEN + 1);
+
+    error_code = bson_get_value_bin(tmp_b, "poster", IDLEN, poster_b, &len);
+    if (error_code) bzero(poster_b, IDLEN + 1);
+
+    return strncmp(poster_b, poster_a, IDLEN);
+}
+
+Err
+_reverse_db_results(bson_t **db_results, int n_results)
+{
+    int half_results = n_results / 2;
+    bson_t **p_db_results = db_results;
+    bson_t **p_end_db_results = db_results + n_results - 1;
+    bson_t *temp;
+    for(int i = 0; i < half_results; i++, p_db_results++, p_end_db_results--) {
+        temp = *p_db_results;
+        *p_db_results = *p_end_db_results;
+        *p_end_db_results = temp;        
+    }
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param comment [description]
+ * @param comment_bson [description]
+ *
+ * @return [description]
+ */
+Err
+_serialize_comment_bson(Comment *comment, bson_t **comment_bson)
+{
+    *comment_bson = BCON_NEW(
+                        "version", BCON_INT32(comment->version),
+                        "the_id", BCON_BINARY(comment->the_id, UUIDLEN),
+                        "main_id", BCON_BINARY(comment->main_id, UUIDLEN),
+                        "status", BCON_INT32(comment->status),
+                        "status_updater", BCON_BINARY((unsigned char *)comment->status_updater, IDLEN),
+                        "status_update_ip", BCON_BINARY((unsigned char *)comment->status_update_ip, IPV4LEN),
+                        "comment_type", BCON_INT32(comment->comment_type),
+                        "karma", BCON_INT32(comment->karma),
+                        "poster", BCON_BINARY((unsigned char *)comment->poster, IDLEN),
+                        "ip", BCON_BINARY((unsigned char *)comment->ip, IPV4LEN),
+                        "create_milli_timestamp", BCON_INT64(comment->create_milli_timestamp),
+                        "updater", BCON_BINARY((unsigned char *)comment->updater, IDLEN),
+                        "update_ip", BCON_BINARY((unsigned char *)comment->update_ip, IPV4LEN),
+                        "update_milli_timestamp", BCON_INT64(comment->update_milli_timestamp),
+                        "len", BCON_INT32(comment->len),
+                        "buf", BCON_BINARY((unsigned char *)comment->buf, comment->len)
+                    );
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param comment_bson [description]
+ * @param comment [description]
+ *
+ * @return [description]
+ */
+Err
+_deserialize_comment_bson(bson_t *comment_bson, Comment *comment)
+{
+    Err error_code;
+
+    int len;
+    error_code = bson_get_value_int32(comment_bson, "version", (int *)&comment->version);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "the_id", UUIDLEN, (char *)comment->the_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "main_id", UUIDLEN, (char *)comment->main_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_bson, "status", (int *)&comment->status);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_bson, "comment_type", (int *)&comment->comment_type);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_bson, "karma", (int *)&comment->karma);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "status_updater", IDLEN, comment->status_updater, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "status_update_ip", IPV4LEN, comment->status_update_ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "poster", IDLEN, comment->poster, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "ip", IPV4LEN, comment->ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(comment_bson, "create_milli_timestamp", (long *)&comment->create_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "updater", IDLEN, comment->updater, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "update_ip", IPV4LEN, comment->update_ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(comment_bson, "update_milli_timestamp", (long *)&comment->update_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_bson, "len", &comment->len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_bson, "buf", comment->max_buf_len, comment->buf, &len);
+    if (error_code) return error_code;
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param comment_bson [description]
+ * @param comment [description]
+ *
+ * @return [description]
+ */
+Err
+_deserialize_comment_bson_with_buf(bson_t *comment_bson, Comment *comment)
+{
+    Err error_code = S_OK;
+    if (comment->buf) return S_ERR;
+
+    int len = 0;
+    error_code = bson_get_value_int32(comment_bson, "len", &len);
+    if (error_code) return error_code;
+
+    comment->buf = malloc(len);
+    comment->max_buf_len = len;
+    comment->len = 0;
+
+    return _deserialize_comment_bson(comment_bson, comment);
+}

--- a/mbbsd/pttdb_comment_reply.c
+++ b/mbbsd/pttdb_comment_reply.c
@@ -1,0 +1,370 @@
+#include "pttdb.h"
+#include "pttdb_internal.h"
+
+Err
+create_comment_reply(UUID main_id, UUID comment_id, char *poster, char *ip, int len, char *content, UUID comment_reply_id)
+{
+    Err error_code = S_OK;
+
+    time64_t create_milli_timestamp;
+
+    // use associate to associate content directly
+    CommentReply comment_reply = {};
+    associate_comment_reply(&comment_reply, content, len);
+    comment_reply.len = len;
+
+    error_code = get_milli_timestamp(&create_milli_timestamp);
+    if (error_code) return error_code;
+
+    // for now we have comment_reply_id same as comment_id to reduce complication.
+    memcpy(comment_reply_id, comment_id, sizeof(UUID));
+
+    // comment_reply
+    memcpy(comment_reply.the_id, comment_reply_id, sizeof(UUID));
+    memcpy(comment_reply.comment_id, comment_id, sizeof(UUID));
+    memcpy(comment_reply.main_id, main_id, sizeof(UUID));
+    comment_reply.status = LIVE_STATUS_ALIVE;
+    strcpy(comment_reply.status_updater, poster);
+    strcpy(comment_reply.status_update_ip, ip);
+
+    strcpy(comment_reply.poster, poster);
+    strcpy(comment_reply.ip, ip);
+    comment_reply.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment_reply.updater, poster);
+    strcpy(comment_reply.update_ip, ip);
+    comment_reply.update_milli_timestamp = create_milli_timestamp;
+
+    error_code = pttdb_count_lines(content, len, &comment_reply.n_line);
+
+    // db-comment
+    bson_t *comment_reply_id_bson = NULL;
+    bson_t *comment_reply_bson = NULL;
+
+    if(!error_code) {
+        error_code = _serialize_comment_reply_bson(&comment_reply, &comment_reply_bson);
+    }
+
+    if (!error_code) {
+        error_code = _serialize_uuid_bson(comment_reply_id, &comment_reply_id_bson);
+    }
+
+    if (!error_code) {
+        error_code = db_update_one(MONGO_COMMENT_REPLY, comment_reply_id_bson, comment_reply_bson, true);
+    }
+
+    bson_safe_destroy(&comment_reply_bson);
+    bson_safe_destroy(&comment_reply_id_bson);
+    dissociate_comment_reply(&comment_reply);
+
+    return error_code;
+
+}
+
+Err
+get_comment_reply_info_by_main(UUID main_id, int *n_comment_reply, int *n_line, int *total_len)
+{
+    Err error_code = S_OK;
+    bson_t *pipeline = BCON_NEW(
+        "pipeline", "[",
+            "{",
+                "$match", "{",
+                    "main_id", BCON_BINARY(main_id, UUIDLEN),
+                    "status", BCON_INT32((int)LIVE_STATUS_ALIVE),
+                "}",
+            "}",
+            "{",
+                "$group", "{",
+                    "_id", BCON_NULL,
+                    "count", "{",
+                        "$sum", BCON_INT32(1),
+                    "}",
+                    "n_line", "{",
+                        "$sum", "$n_line",
+                    "}",
+                    "len", "{",
+                        "$sum", "$len",
+                    "}",
+                "}",
+            "}",
+        "]"
+    );
+
+    if (pipeline == NULL) error_code = S_ERR;
+
+    bson_t *result = NULL;
+
+    int n_result = 0;
+    if (!error_code) {
+        error_code = db_aggregate(MONGO_COMMENT_REPLY, pipeline, 1, &result, &n_result);
+    }
+
+    if (!error_code) {
+        error_code = _get_comment_reply_info_by_main_deal_with_result(result, n_result, n_comment_reply, n_line, total_len);
+    }
+
+    bson_safe_destroy(&result);
+    bson_safe_destroy(&pipeline);
+
+    return error_code;
+}
+
+Err
+read_comment_reply(UUID comment_reply_id, CommentReply *comment_reply)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+                      "the_id", BCON_BINARY(comment_reply_id, UUIDLEN)
+                  );
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_COMMENT_REPLY, key, NULL, &db_result);
+
+    if (!error_code) {
+        error_code = _deserialize_comment_reply_bson(db_result, comment_reply);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&db_result);
+    return error_code;
+}
+
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_id [description]
+ * @param updater [description]
+ * @param char [description]
+ * @return [description]
+ */
+Err
+delete_comment_reply(UUID comment_reply_id, char *updater, char *ip) {
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+        "the_id", BCON_BINARY(comment_reply_id, UUIDLEN)
+    );
+
+    bson_t *val = BCON_NEW(
+        "status_updater", BCON_BINARY((unsigned char *)updater, IDLEN),
+        "status", BCON_INT32((int)LIVE_STATUS_DELETED),
+        "status_update_ip", BCON_BINARY((unsigned char *)ip, IPV4LEN)
+    );
+
+    error_code = db_update_one(MONGO_COMMENT_REPLY, key, val, true);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+    return error_code;
+}
+
+
+Err
+init_comment_reply_buf(CommentReply *comment_reply)
+{
+    if (comment_reply->buf != NULL) return S_OK;
+
+    comment_reply->buf = malloc(MAX_BUF_SIZE);
+    if (comment_reply->buf == NULL) return S_ERR;
+
+    comment_reply->max_buf_len = MAX_BUF_SIZE;
+    bzero(comment_reply->buf, MAX_BUF_SIZE);
+    comment_reply->len = 0;
+    comment_reply->n_line = 0;
+
+    return S_OK;
+}
+
+Err
+destroy_comment_reply(CommentReply *comment_reply)
+{
+    if (comment_reply->buf == NULL) return S_OK;
+
+    free(comment_reply->buf);
+    comment_reply->buf = NULL;
+    comment_reply->max_buf_len = 0;
+    comment_reply->len = 0;
+    comment_reply->n_line = 0;
+
+    return S_OK;
+}
+
+Err
+associate_comment_reply(CommentReply *comment_reply, char *buf, int max_buf_len)
+{
+    if (comment_reply->buf != NULL) return S_ERR;
+
+    comment_reply->buf = buf;
+    comment_reply->max_buf_len = max_buf_len;
+    comment_reply->len = 0;
+    comment_reply->n_line = 0;
+
+    return S_OK;
+}
+
+Err
+dissociate_comment_reply(CommentReply *comment_reply)
+{
+    if (comment_reply->buf == NULL) return S_OK;
+
+    comment_reply->buf = NULL;
+    comment_reply->max_buf_len = 0;
+    comment_reply->len = 0;
+    comment_reply->n_line = 0;
+
+    return S_OK;
+}
+
+Err
+_get_comment_reply_info_by_main_deal_with_result(bson_t *result, int n_result, int *n_comment_reply, int *n_line, int *total_len)
+{
+    if(!n_result) {
+        *n_comment_reply = 0;
+        *n_line = 0;
+        *total_len = 0;
+        return S_OK;
+    }
+
+    Err error_code = S_OK;
+
+    error_code = bson_get_value_int32(result, "count", n_comment_reply);
+
+    if (!error_code) {
+        error_code = bson_get_value_int32(result, "n_line", n_line);
+    }
+
+    if (!error_code) {
+        error_code = bson_get_value_int32(result, "len", total_len);
+    }
+
+    return error_code;    
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param comment [description]
+ * @param comment_bson [description]
+ *
+ * @return [description]
+ */
+Err
+_serialize_comment_reply_bson(CommentReply *comment_reply, bson_t **comment_reply_bson)
+{
+    *comment_reply_bson = BCON_NEW(
+                        "version", BCON_INT32(comment_reply->version),
+                        "the_id", BCON_BINARY(comment_reply->the_id, UUIDLEN),
+                        "comment_id", BCON_BINARY(comment_reply->comment_id, UUIDLEN),
+                        "main_id", BCON_BINARY(comment_reply->main_id, UUIDLEN),
+                        "status", BCON_INT32(comment_reply->status),
+                        "status_updater", BCON_BINARY((unsigned char *)comment_reply->status_updater, IDLEN),
+                        "status_update_ip", BCON_BINARY((unsigned char *)comment_reply->status_update_ip, IPV4LEN),
+                        "poster", BCON_BINARY((unsigned char *)comment_reply->poster, IDLEN),
+                        "ip", BCON_BINARY((unsigned char *)comment_reply->ip, IPV4LEN),
+                        "create_milli_timestamp", BCON_INT64(comment_reply->create_milli_timestamp),
+                        "updater", BCON_BINARY((unsigned char *)comment_reply->updater, IDLEN),
+                        "update_ip", BCON_BINARY((unsigned char *)comment_reply->update_ip, IPV4LEN),
+                        "update_milli_timestamp", BCON_INT64(comment_reply->update_milli_timestamp),
+                        "len", BCON_INT32(comment_reply->len),
+                        "n_line", BCON_INT32(comment_reply->n_line),
+                        "buf", BCON_BINARY((unsigned char *)comment_reply->buf, comment_reply->len)
+                    );
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param comment_bson [description]
+ * @param comment [description]
+ *
+ * @return [description]
+ */
+Err
+_deserialize_comment_reply_bson(bson_t *comment_reply_bson, CommentReply *comment_reply)
+{
+    Err error_code;
+
+    int len;
+    error_code = bson_get_value_int32(comment_reply_bson, "version", (int *)&comment_reply->version);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "the_id", UUIDLEN, (char *)comment_reply->the_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "comment_id", UUIDLEN, (char *)comment_reply->comment_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "main_id", UUIDLEN, (char *)comment_reply->main_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_reply_bson, "status", (int *)&comment_reply->status);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "status_updater", IDLEN, comment_reply->status_updater, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "status_update_ip", IPV4LEN, comment_reply->status_update_ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "poster", IDLEN, comment_reply->poster, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "ip", IPV4LEN, comment_reply->ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(comment_reply_bson, "create_milli_timestamp", (long *)&comment_reply->create_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "updater", IDLEN, comment_reply->updater, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "update_ip", IPV4LEN, comment_reply->update_ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(comment_reply_bson, "update_milli_timestamp", (long *)&comment_reply->update_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_reply_bson, "len", &comment_reply->len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(comment_reply_bson, "n_line", &comment_reply->n_line);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(comment_reply_bson, "buf", comment_reply->max_buf_len, comment_reply->buf, &len);
+    if (error_code) return error_code;
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param comment_bson [description]
+ * @param comment [description]
+ *
+ * @return [description]
+ */
+Err
+_deserialize_comment_reply_bson_with_buf(bson_t *comment_reply_bson, CommentReply *comment_reply)
+{
+    Err error_code = S_OK;
+    if (comment_reply->buf) return S_ERR;
+
+    int len = 0;
+    error_code = bson_get_value_int32(comment_reply_bson, "len", &len);
+    if (error_code) return error_code;
+
+    comment_reply->buf = malloc(len);
+    comment_reply->max_buf_len = len;
+    comment_reply->len = 0;
+    comment_reply->n_line = 0;
+
+    return _deserialize_comment_reply_bson(comment_reply_bson, comment_reply);
+}

--- a/mbbsd/pttdb_content_block.c
+++ b/mbbsd/pttdb_content_block.c
@@ -1,0 +1,707 @@
+#include "pttdb.h"
+#include "pttdb_internal.h"
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param buf [description]
+ * @param bytes [description]
+ * @param ref_id [description]
+ * @param conten_id [description]
+ * @param MongoDBId [description]
+ * @param n_line [description]
+ * @param n_block [description]
+ */
+Err
+split_contents(char *buf, int bytes, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, int *n_line, int *n_block) {
+    Err error_code = S_OK;
+    int bytes_in_line = 0;
+    char line[MAX_BUF_SIZE] = {};
+
+    ContentBlock content_block = {};
+
+    // init
+    (*n_block) = 0;
+    error_code = init_content_block_with_buf_block(&content_block, ref_id, content_id, *n_block);
+    (*n_block)++;
+
+    if (!error_code) {
+        error_code = _split_contents_core(buf, bytes, ref_id, content_id, mongo_db_id, n_line, n_block, line, &bytes_in_line, &content_block);
+    }
+
+    if (!error_code) {
+        error_code = _split_contents_deal_with_last_line_block(bytes_in_line, line, ref_id, content_id, mongo_db_id, &content_block, n_line, n_block);
+    }
+
+    destroy_content_block(&content_block);
+
+    return error_code;
+}
+
+Err
+split_contents_from_fd(int fd_content, int len, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, int *n_line, int *n_block) {
+    Err error_code = S_OK;
+    char buf[MAX_BUF_SIZE] = {};
+    char line[MAX_BUF_SIZE] = {};
+    int bytes = 0;
+    int buf_size = 0;
+    int bytes_in_line = 0;
+    ContentBlock content_block = {};
+
+    // init
+    *n_block = 0;
+    error_code = init_content_block_with_buf_block(&content_block, ref_id, content_id, *n_block);
+    (*n_block)++;
+
+    if (!error_code) {
+        while ((buf_size = len < MAX_BUF_SIZE ? len : MAX_BUF_SIZE) && (bytes = read(fd_content, buf, buf_size)) > 0) {
+            error_code = _split_contents_core(buf, bytes, ref_id, content_id, mongo_db_id, n_line, n_block, line, &bytes_in_line, &content_block);
+            if (error_code) break;
+
+            len -= bytes;
+        }
+    }
+
+    if (!error_code) {
+        error_code = _split_contents_deal_with_last_line_block(bytes_in_line, line, ref_id, content_id, mongo_db_id, &content_block, n_line, n_block);
+    }
+
+    destroy_content_block(&content_block);
+
+    return error_code;
+}
+
+Err
+delete_content(UUID content_id, enum MongoDBId mongo_db_id)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW("the_id", BCON_BINARY(content_id, UUIDLEN));
+    if (key == NULL) error_code = S_ERR_INIT;
+
+    if (!error_code) {
+        error_code = db_remove(mongo_db_id, key);
+    }
+
+    bson_safe_destroy(&key);
+
+    return error_code;
+}
+
+Err
+reset_content_block(ContentBlock *content_block, UUID ref_id, UUID content_id, int block_id)
+{
+    reset_content_block_buf_block(content_block);
+
+    memcpy(content_block->the_id, content_id, sizeof(UUID));
+    memcpy(content_block->ref_id, ref_id, sizeof(UUID));
+
+    content_block->block_id = block_id;
+
+    return S_OK;
+}
+
+Err
+reset_content_block_buf_block(ContentBlock *content_block)
+{
+    if (!content_block->len_block) return S_OK;
+
+    bzero(content_block->buf_block, content_block->len_block);
+    content_block->len_block = 0;
+    content_block->n_line = 0;
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details initialize new content-block with block-id as current n_block.
+ *
+ * @param content_block [description]
+ * @param ref_id [description]
+ * @param content_id [description]
+ * @param n_block [description]
+ */
+Err
+init_content_block_with_buf_block(ContentBlock *content_block, UUID ref_id, UUID content_id, int block_id)
+{
+    Err error_code = init_content_block_buf_block(content_block);
+
+    if (error_code) return error_code;
+
+    error_code = reset_content_block(content_block, ref_id, content_id, block_id);
+    if (error_code) return error_code;
+
+    return S_OK;
+}
+
+Err
+init_content_block_buf_block(ContentBlock *content_block)
+{
+    if (content_block->buf_block != NULL) return S_OK;
+
+    content_block->buf_block = malloc(MAX_BUF_SIZE);
+    if (content_block->buf_block == NULL) return S_ERR;
+
+    content_block->max_buf_len = MAX_BUF_SIZE;
+    bzero(content_block->buf_block, MAX_BUF_SIZE);
+    content_block->len_block = 0;
+
+    return S_OK;
+}
+
+Err
+destroy_content_block(ContentBlock *content_block)
+{
+    if (content_block->buf_block == NULL) return S_OK;
+
+    free(content_block->buf_block);
+    content_block->buf_block = NULL;
+    content_block->max_buf_len = 0;
+    content_block->len_block = 0;
+
+    return S_OK;
+}
+
+Err
+associate_content_block(ContentBlock *content_block, char *buf_block, int max_buf_len)
+{
+    if (content_block->buf_block != NULL) return S_ERR;
+
+    content_block->buf_block = buf_block;
+    content_block->max_buf_len = max_buf_len;
+    content_block->len_block = 0;
+
+    return S_OK;
+}
+
+Err
+dissociate_content_block(ContentBlock *content_block)
+{
+    if (content_block->buf_block == NULL) return S_OK;
+
+    content_block->buf_block = NULL;
+    content_block->max_buf_len = 0;
+    content_block->len_block = 0;
+
+    return S_OK;
+}
+
+Err
+save_content_block(ContentBlock *content_block, enum MongoDBId mongo_db_id)
+{
+    Err error_code = S_OK;
+    if (content_block->buf_block == NULL) return S_ERR;
+
+    bson_t *content_block_bson = NULL;
+    bson_t *content_block_id_bson = NULL;
+
+    char tmp_ref_id[UUIDLEN + 1] = {};
+    char tmp_the_id[UUIDLEN + 1] = {};
+    memcpy(tmp_ref_id, content_block->ref_id, UUIDLEN);
+    memcpy(tmp_the_id, content_block->the_id, UUIDLEN);
+
+    error_code = _serialize_content_block_bson(content_block, &content_block_bson);
+
+    if (!error_code) {
+        error_code = _serialize_content_uuid_bson(content_block->the_id, content_block->block_id, &content_block_id_bson);
+    }
+
+    if (!error_code) {
+        error_code = db_update_one(mongo_db_id, content_block_id_bson, content_block_bson, true);
+    }
+
+    bson_safe_destroy(&content_block_bson);
+    bson_safe_destroy(&content_block_id_bson);
+
+    return error_code;
+}
+
+Err
+read_content_block(UUID content_id, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_block)
+{
+    Err error_code = S_OK;
+
+    if (content_block->buf_block == NULL) return S_ERR;
+
+    bson_t *key = BCON_NEW(
+                      "the_id", BCON_BINARY(content_id, UUIDLEN),
+                      "block_id", BCON_INT32(block_id)
+                  );
+    if (key == NULL) error_code = S_ERR;
+
+    bson_t *db_result = NULL;
+
+    if (!error_code) {
+        error_code = db_find_one(mongo_db_id, key, NULL, &db_result);
+    }
+
+    if (!error_code) {
+        error_code = _deserialize_content_block_bson(db_result, content_block);
+    }
+
+    bson_safe_destroy(&db_result);
+    bson_safe_destroy(&key);
+
+    return error_code;
+}
+
+Err
+read_content_blocks(UUID content_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_blocks, int *n_block, int *len)
+{
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+                      "the_id", BCON_BINARY(content_id, UUIDLEN)
+                  );
+    if (key == NULL) error_code = S_ERR;
+
+    if(!error_code) {
+        error_code = _read_content_blocks_core(key, max_n_block, block_id, mongo_db_id, content_blocks, n_block, len);
+    }
+
+    bson_safe_destroy(&key);
+
+    return error_code;
+}
+
+Err
+read_content_blocks_by_ref(UUID ref_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_blocks, int *n_block, int *len)
+{
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+                      "ref_id", BCON_BINARY(ref_id, UUIDLEN)
+                  );
+    if (key == NULL) error_code = S_ERR;
+
+    if(!error_code) {
+        error_code = _read_content_blocks_core(key, max_n_block, block_id, mongo_db_id, content_blocks, n_block, len);
+    }
+
+    bson_safe_destroy(&key);
+
+    return error_code;
+}
+
+Err
+_read_content_blocks_core(bson_t *key, int max_n_block, int block_id, enum MongoDBId mongo_db_id, ContentBlock *content_blocks, int *n_block, int *len)
+{
+    Err error_code = S_OK;
+    // init db_results
+    bson_t **db_results = malloc(sizeof(bson_t *) * max_n_block);
+    if (db_results == NULL) return S_ERR_INIT;
+    bzero(db_results, sizeof(bson_t *) * max_n_block);
+
+    if (!error_code) {
+        error_code = _read_content_blocks_get_db_results(db_results, key, max_n_block, block_id, mongo_db_id, n_block);
+    }
+
+    // db_results to content-blocks
+    int tmp_n_block = *n_block;
+    bson_t **p_db_results = db_results;
+    ContentBlock *p_content_blocks = content_blocks;
+
+    int tmp_len = 0;
+    if (!error_code) {
+        for (int i = 0; i < tmp_n_block; i++) {
+            error_code = _deserialize_content_block_bson(*p_db_results, p_content_blocks);
+
+            tmp_len += p_content_blocks->len_block;
+            p_db_results++;
+            p_content_blocks++;
+
+            if (error_code) {
+                *n_block = i;
+                break;
+            }
+        }
+    }
+
+    *len = tmp_len;
+
+    // free
+    p_db_results = db_results;
+    for (int i = 0; i < tmp_n_block; i++) {
+        bson_safe_destroy(p_db_results);
+        p_db_results++;
+    }
+    free(db_results);
+
+    return error_code;
+}
+
+/**
+ * @brief Cconten
+ * @details content blocks does not init with buf. All the content blocks shares buf
+ *
+ * @param content_id [description]
+ * @param max_n_blocks [description]
+ * @param block_id [description]
+ * @param MongoDBId [description]
+ * @param content_blocks [description]
+ * @param n_blocks [description]
+ */
+Err
+dynamic_read_content_blocks(UUID content_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, char *buf, int max_buf_size, ContentBlock *content_blocks, int *n_block, int *len)
+{
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+                      "the_id", BCON_BINARY(content_id, UUIDLEN)
+                  );
+    if(key == NULL) error_code = S_ERR;
+
+    if(!error_code){
+        error_code = _dynamic_read_content_blocks_core(key, max_n_block, block_id, mongo_db_id, buf, max_buf_size, content_blocks, n_block, len);
+    }
+
+    bson_safe_destroy(&key);
+
+    return error_code;
+}
+
+Err
+dynamic_read_content_blocks_by_ref(UUID ref_id, int max_n_block, int block_id, enum MongoDBId mongo_db_id, char *buf, int max_buf_size, ContentBlock *content_blocks, int *n_block, int *len)
+{
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+                      "ref_id", BCON_BINARY(ref_id, UUIDLEN)
+                  );
+    if(key == NULL) error_code = S_ERR;
+
+    if(!error_code) {
+        error_code = _dynamic_read_content_blocks_core(key, max_n_block, block_id, mongo_db_id, buf, max_buf_size, content_blocks, n_block, len);
+    }
+
+    bson_safe_destroy(&key);
+
+    return error_code;    
+}
+
+Err
+_dynamic_read_content_blocks_core(bson_t *key, int max_n_block, int block_id, enum MongoDBId mongo_db_id, char *buf, int max_buf_size, ContentBlock *content_blocks, int *n_block, int *len)
+{
+    Err error_code = S_OK;
+    // init db_results
+    bson_t **db_results = malloc(sizeof(bson_t *) * max_n_block);
+    if (db_results == NULL) return S_ERR_INIT;
+    bzero(db_results, sizeof(bson_t *) * max_n_block);
+
+    error_code = _read_content_blocks_get_db_results(db_results, key, max_n_block, block_id, mongo_db_id, n_block);
+    fprintf(stderr, "_dynamic_read_content_blocks_core: after _read_content_blocks_get_db_results: error_code: %d\n", error_code);
+
+    // db_results to content-blocks
+    int tmp_n_block = *n_block;
+    bson_t **p_db_results = db_results;
+    ContentBlock *p_content_blocks = content_blocks;
+    char *p_buf = buf;
+    int tmp_len_block = 0;
+    int tmp_len = 0;
+
+    if (!error_code) {
+        for (int i = 0; i < tmp_n_block; i++) {
+            if (max_buf_size < 0) {
+                error_code = S_ERR_BUFFER_LEN;
+                break;
+            }
+
+            p_content_blocks->buf_block = p_buf;
+            p_content_blocks->max_buf_len = max_buf_size;
+
+            error_code = _deserialize_content_block_bson(*p_db_results, p_content_blocks);
+
+            tmp_len_block = p_content_blocks->len_block;
+            p_content_blocks->max_buf_len = tmp_len_block;
+            max_buf_size -= tmp_len_block;
+            p_buf += tmp_len_block;
+            tmp_len += tmp_len_block;
+
+            p_db_results++;
+            p_content_blocks++;
+
+            if (error_code) {
+                *n_block = i;
+                break;
+            }
+        }
+    }
+
+    *len = tmp_len;
+
+    // free
+    p_db_results = db_results;
+    for (int i = 0; i < tmp_n_block; i++) {
+        bson_safe_destroy(p_db_results);
+        p_db_results++;
+    }
+    free(db_results);
+
+    return error_code;
+}
+
+Err
+_read_content_blocks_get_db_results(bson_t **db_results, bson_t *key, int max_n_block, int block_id, enum MongoDBId mongo_db_id, int *n_block)
+{
+    Err error_code = S_OK;
+
+    bson_t *b_array_block_ids = bson_new();
+    if (b_array_block_ids == NULL) error_code = S_ERR_INIT;
+
+    if (!error_code) {
+        error_code = _form_b_array_block_ids(block_id, max_n_block, b_array_block_ids);
+    }
+
+    bool status = true;
+    if (!error_code) {
+        status = bson_append_document(key, "block_id", -1, b_array_block_ids);
+        if (!status) error_code = S_ERR;
+    }
+
+    if (!error_code) {
+        error_code = db_find(mongo_db_id, key, NULL, NULL, max_n_block, n_block, db_results);
+    }
+
+    int tmp_n_block = *n_block;
+
+    if (!error_code) {
+        error_code = _sort_by_block_id(db_results, tmp_n_block);
+    }
+    if (!error_code) {
+        error_code = _ensure_block_ids(db_results, block_id, tmp_n_block);
+    }
+
+    bson_safe_destroy(&b_array_block_ids);
+
+    return error_code;
+}
+
+Err
+_form_b_array_block_ids(int block_id, int max_n_block, bson_t *b)
+{
+    Err error_code = S_OK;
+
+    bson_t child;
+    char buf[16];
+    const char *key;
+    size_t keylen;
+
+    bool status;
+
+    BSON_APPEND_ARRAY_BEGIN(b, "$in", &child);
+    for (int i = 0; i < max_n_block; i++) {
+        keylen = bson_uint32_to_string(i, &key, buf, sizeof(buf));
+        status = bson_append_int32(&child, key, (int)keylen, block_id + i);
+        if (!status) {
+            error_code = S_ERR_INIT;
+            break;
+        }
+    }
+    bson_append_array_end(b, &child);
+
+    return error_code;
+}
+
+Err
+_sort_by_block_id(bson_t **db_results, int n_block)
+{
+    qsort(db_results, n_block, sizeof(bson_t *), _cmp_sort_by_block_id);
+
+    return S_OK;
+}
+
+int
+_cmp_sort_by_block_id(const void *a, const void *b)
+{
+    bson_t **tmp_tmp_a = (bson_t **)a;
+    bson_t *tmp_a = *tmp_tmp_a;
+    bson_t **tmp_tmp_b = (bson_t **)b;
+    bson_t *tmp_b = *tmp_tmp_b;
+    int block_id_a = 0;
+    int block_id_b = 0;
+
+    Err error_code = S_OK;
+
+    error_code = bson_get_value_int32(tmp_a, "block_id", &block_id_a);
+    if (error_code) block_id_a = -1;
+
+    error_code = bson_get_value_int32(tmp_b, "block_id", &block_id_b);
+    if (error_code) block_id_b = -1;
+
+    return block_id_a - block_id_b;
+}
+
+Err
+_ensure_block_ids(bson_t **db_results, int start_block_id, int n_block)
+{
+    Err error_code = S_OK;
+    int db_block_id;
+    bson_t **p_db_results = db_results;
+    for (int i = 0; i < n_block; i++, p_db_results++) {
+        error_code = bson_get_value_int32(*p_db_results, "block_id", &db_block_id);
+
+        if (error_code) db_block_id = -1;
+
+        if (db_block_id != i + start_block_id) return S_ERR;
+
+    }
+
+    return S_OK;
+}
+
+/**
+ * @brief core for split contents.
+ * @details core for split contents. No need to deal with last line block if used by split_contents_from_fd
+ *          (There are multiple input-bufs in split_contents_from_fd and split_contents_from_fd will take care of last line-block)
+ *
+ * @param buf [description]
+ * @param bytes [description]
+ * @param ref_id [description]
+ * @param content_id [description]
+ * @param MongoDBId [description]
+ * @param n_line [description]
+ * @param n_block [description]
+ * @param is_deal_wtih_last_line_block [description]
+ */
+Err
+_split_contents_core(char *buf, int bytes, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, int *n_line, int *n_block, char *line, int *bytes_in_line, ContentBlock *content_block)
+{
+    Err error_code;
+
+    int bytes_in_new_line = 0;
+    for (int offset_buf = 0; offset_buf < bytes; offset_buf += bytes_in_new_line) {
+        error_code = get_line_from_buf(buf, offset_buf, bytes, line, *bytes_in_line, &bytes_in_new_line);
+        *bytes_in_line += bytes_in_new_line;
+        // unable to get more lines from buf
+        if (error_code) break;
+
+        // Main-op
+        error_code = _split_contents_core_one_line(line, *bytes_in_line, ref_id, content_id, mongo_db_id, content_block, n_line, n_block);
+        if (error_code) return error_code;
+
+        // reset line
+        bzero(line, sizeof(char) * *bytes_in_line);
+        *bytes_in_line = 0;
+    }
+
+    return S_OK;
+}
+
+Err
+_split_contents_core_one_line(char *line, int bytes_in_line, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, ContentBlock *content_block, int *n_line, int *n_block)
+{
+    Err error_code;
+
+    // check for max-lines in block-buf
+    // check for max-buf in block-buf
+    if (content_block->n_line >= MAX_BUF_LINES ||
+            content_block->len_block + bytes_in_line > MAX_BUF_BLOCK) {
+
+        error_code = save_content_block(content_block, mongo_db_id);
+        if (error_code) return error_code;
+
+        error_code = reset_content_block(content_block, ref_id, content_id, *n_block);
+        (*n_block)++;
+        if (error_code) return error_code;
+    }
+
+    memcpy(content_block->buf_block + content_block->len_block, line, bytes_in_line);
+    content_block->len_block += bytes_in_line;
+
+    // 1 more line
+    if (line[bytes_in_line - 2] == '\r' && line[bytes_in_line - 1] == '\n') {
+        (*n_line)++;
+        content_block->n_line++;
+    }
+
+    return S_OK;
+}
+
+Err
+_split_contents_deal_with_last_line_block(int bytes_in_line, char *line, UUID ref_id, UUID content_id, enum MongoDBId mongo_db_id, ContentBlock *content_block, int *n_line, int *n_block)
+{
+    Err error_code = S_OK;
+
+    // last line
+    if (bytes_in_line) {
+        // Main-op
+        error_code = _split_contents_core_one_line(line, bytes_in_line, ref_id, content_id, mongo_db_id, content_block, n_line, n_block);
+        if (error_code) return error_code;
+    }
+
+    // last block
+    if (content_block->len_block) {
+        error_code = save_content_block(content_block, mongo_db_id);
+        if (error_code) return error_code;
+    }
+
+    return S_OK;
+}
+
+/**
+ * @brief Serialize main-content-block to bson
+ * @details Serialize main-content-block to bson
+ *
+ * @param main_content_block main-content-block
+ * @param main_content_block_bson main_content_block_bson (to-compute)
+ * @return Err
+ */
+Err
+_serialize_content_block_bson(ContentBlock *content_block, bson_t **content_block_bson)
+{
+    *content_block_bson = BCON_NEW(
+                              "the_id", BCON_BINARY(content_block->the_id, UUIDLEN),
+                              "ref_id", BCON_BINARY(content_block->ref_id, UUIDLEN),
+                              "block_id", BCON_INT32(content_block->block_id),
+                              "len_block", BCON_INT32(content_block->len_block),
+                              "n_line", BCON_INT32(content_block->n_line),
+                              "buf_block", BCON_BINARY((unsigned char *)content_block->buf_block, content_block->len_block)
+                          );
+
+    return S_OK;
+}
+
+/**
+ * @brief Deserialize bson to content-block
+ * @details Deserialize bson to content-block (receive only len_block, not dealing with '\0' in the end)
+ *
+ * @param main_content_block_bson [description]
+ * @param main_content_block [description]
+ *
+ * @return [description]
+ */
+Err
+_deserialize_content_block_bson(bson_t *content_block_bson, ContentBlock *content_block)
+{
+    Err error_code;
+
+    if (content_block->buf_block == NULL) return S_ERR;
+
+    int len;
+    error_code = bson_get_value_bin(content_block_bson, "the_id", UUIDLEN, (char *)content_block->the_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(content_block_bson, "ref_id", UUIDLEN, (char *)content_block->ref_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(content_block_bson, "block_id", &content_block->block_id);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(content_block_bson, "len_block", &content_block->len_block);
+    if (error_code) return error_code;
+
+    if (content_block->max_buf_len < content_block->len_block) {
+        content_block->len_block = 0;
+        return S_ERR_BUFFER_LEN;
+    }
+
+    error_code = bson_get_value_int32(content_block_bson, "n_line", &content_block->n_line);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(content_block_bson, "buf_block", content_block->max_buf_len, content_block->buf_block, &len);
+    if (error_code) return error_code;
+
+
+    return S_OK;
+}

--- a/mbbsd/pttdb_main.c
+++ b/mbbsd/pttdb_main.c
@@ -1,0 +1,570 @@
+#include "pttdb.h"
+#include "pttdb_internal.h"
+
+/**
+ * @brief Create main from fd
+ * @details Create main from fd
+ *
+ * @param aid aid
+ * @param title title
+ * @param poster poster
+ * @param ip ip
+ * @param origin origin
+ * @param web_link web_link
+ * @param len length of the content
+ * @param fd_content fd
+ * @param main_id (to-compute)
+ * @return Err
+ */
+Err
+create_main_from_fd(aidu_t aid, char *board, char *title, char *poster, char *ip, char *origin, char *web_link, int len, int fd_content, UUID main_id, UUID content_id)
+{
+
+    Err error_code = S_OK;
+    int n_line = 0;
+    int n_block = 0;
+
+    time64_t create_milli_timestamp;
+
+    MainHeader main_header = {};
+
+    error_code = get_milli_timestamp(&create_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = gen_uuid_with_db(MONGO_MAIN, main_id);
+    if (error_code) return error_code;
+
+    error_code = gen_content_uuid_with_db(MONGO_MAIN_CONTENT, content_id);
+    if (error_code) return error_code;
+
+    // main_header
+    memcpy(main_header.the_id, main_id, sizeof(UUID));
+    memcpy(main_header.content_id, content_id, sizeof(UUID));
+    memcpy(main_header.update_content_id, content_id, sizeof(UUID));
+    main_header.aid = aid;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.board, board);
+    strcpy(main_header.status_updater, poster);
+    strcpy(main_header.status_update_ip, ip);
+    strcpy(main_header.title, title);
+    strcpy(main_header.poster, poster);
+    strcpy(main_header.ip, ip);
+    strcpy(main_header.updater, poster);
+    strcpy(main_header.update_ip, ip);
+    main_header.create_milli_timestamp = create_milli_timestamp;
+    main_header.update_milli_timestamp = create_milli_timestamp;
+    strcpy(main_header.origin, origin);
+    strcpy(main_header.web_link, web_link);
+    main_header.reset_karma = 0;
+
+    // main_contents
+    error_code = split_contents_from_fd(fd_content, len, main_id, content_id, MONGO_MAIN_CONTENT, &n_line, &n_block);
+    if (error_code) return error_code;
+
+    // db-main
+    main_header.len_total = len;
+    main_header.n_total_line = n_line;
+    main_header.n_total_block = n_block;
+
+    bson_t *main_id_bson = NULL;
+    bson_t *main_bson = NULL;
+    if(!error_code) {
+        error_code = _serialize_main_bson(&main_header, &main_bson);
+    }
+
+    char *str = bson_as_canonical_extended_json(main_bson, NULL);
+    fprintf(stderr, "pttdb_main.create_main_from_fd: main_bson: %s\n", str);
+    bson_free(str);
+
+    if (!error_code) {
+        error_code = _serialize_uuid_bson(main_id, &main_id_bson);
+    }
+
+    str = bson_as_canonical_extended_json(main_id_bson, NULL);
+    fprintf(stderr, "pttdb_main.create_main_from_fd: main_id_bson: %s\n", str);
+    bson_free(str);
+
+    if(!error_code) {
+        error_code = db_update_one(MONGO_MAIN, main_id_bson, main_bson, true);
+    }
+
+    bson_safe_destroy(&main_bson);
+    bson_safe_destroy(&main_id_bson);
+
+    return error_code;
+}
+
+/**
+ * @brief Get total size of main from main_id
+ * @details [long description]
+ *
+ * @param main_id main_id
+ * @param len total-size of the main.
+ *
+ * @return Err
+ */
+Err
+len_main(UUID main_id, int *len)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "the_id", BCON_BINARY(main_id, UUIDLEN)
+        );
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "the_id", BCON_BOOL(true),
+        "len_total", BCON_BOOL(true)
+        );
+
+    bson_t *db_result = NULL;
+
+    error_code = db_find_one(MONGO_MAIN, key, fields, &db_result);
+
+    if(!error_code) {
+        error_code = bson_get_value_int32(db_result, "len_total", len);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&db_result);
+
+    return error_code;
+}
+
+/**
+ * @brief Get total size of main from aid
+ * @details
+ *
+ * @param aid aid
+ * @return Err
+ */
+Err
+len_main_by_aid(aidu_t aid, int *len)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "aid", BCON_INT64(aid)
+        );
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "aid", BCON_BOOL(true),
+        "len_total", BCON_BOOL(true)
+        );
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_MAIN, key, fields, &db_result);
+    if(!error_code) {
+        error_code = bson_get_value_int32(db_result, "len_total", len);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&db_result);
+
+    return error_code;
+}
+
+/**
+ * @brief get total-lines of main from main_id
+ * @details [long description]
+ *
+ * @param main_id main-id
+ * @param n_line n-line
+ *
+ * @return Err
+ */
+Err
+n_line_main(UUID main_id, int *n_line)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "the_id", BCON_BINARY(main_id, UUIDLEN)
+        );
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "n_total_line", BCON_BOOL(true)
+        );
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_MAIN, key, fields, &db_result);
+
+    if(!error_code) {
+        error_code = bson_get_value_int32(db_result, "n_total_line", n_line);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&db_result);
+
+    return error_code;
+}
+
+/**
+ * @brief get total-lines of main from aid
+ * @details [long description]
+ *
+ * @param aid aid
+ * @param n_line n-line
+ *
+ * @return Err
+ */
+Err
+n_line_main_by_aid(aidu_t aid, int *n_line)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "aid", BCON_INT64(aid)
+        );
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "n_total_line", BCON_BOOL(true)
+        );
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_MAIN, key, fields, &db_result);
+
+    if(!error_code) {
+        error_code = bson_get_value_int32(db_result, "n_total_line", n_line);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&db_result);
+
+    return error_code;
+}
+
+/**
+ * @brief read main header
+ * @details [long description]
+ *
+ * @param main_id main-id
+ * @param main_header main-header
+ *
+ * @return Err
+ */
+Err
+read_main_header(UUID main_id, MainHeader *main_header)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "the_id", BCON_BINARY(main_id, UUIDLEN)
+        );
+
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_MAIN, key, NULL, &db_result);
+
+    if(!error_code) {
+        error_code = _deserialize_main_bson(db_result, main_header);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&db_result);
+    return error_code;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param aid [description]
+ * @param main [description]
+ *
+ * @return [description]
+ */
+Err
+read_main_header_by_aid(aidu_t aid, MainHeader *main_header)
+{
+    Err error_code = S_OK;
+    bson_t *key = BCON_NEW(
+        "aid", BCON_INT64(aid)
+        );
+
+
+    bson_t *db_result = NULL;
+    error_code = db_find_one(MONGO_MAIN, key, NULL, &db_result);
+
+    if(!error_code) {
+        error_code = _deserialize_main_bson(db_result, main_header);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&db_result);
+    return error_code;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_id [description]
+ * @param updater [description]
+ * @param char [description]
+ * @return [description]
+ */
+Err
+delete_main(UUID main_id, char *updater, char *ip) {
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+        "the_id", BCON_BINARY(main_id, UUIDLEN)
+        );
+
+    bson_t *val = BCON_NEW(
+        "status_updater", BCON_BINARY((unsigned char *)updater, IDLEN),
+        "status", BCON_INT32((int)LIVE_STATUS_DELETED),
+        "status_update_ip", BCON_BINARY((unsigned char *)ip, IPV4LEN)
+        );
+
+    error_code = db_update_one(MONGO_MAIN, key, val, true);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+    return error_code;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_id [description]
+ * @param updater [description]
+ * @param char [description]
+ * @return [description]
+ */
+Err
+delete_main_by_aid(aidu_t aid, char *updater, char *ip) {
+    Err error_code = S_OK;
+
+    bson_t *key = BCON_NEW(
+        "aid", BCON_INT64(aid)
+        );
+
+    bson_t *val = BCON_NEW(
+        "status_updater", BCON_BINARY((unsigned char *)updater, IDLEN),
+        "status", BCON_INT32((int)LIVE_STATUS_DELETED),
+        "status_update_ip", BCON_BINARY((unsigned char *)ip, IPV4LEN)
+        );
+
+    error_code = db_update_one(MONGO_MAIN, key, val, true);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+    return error_code;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_id [description]
+ * @param title [description]
+ * @param updater [description]
+ * @param char [description]
+ * @param len [description]
+ * @param fd_content [description]
+ * @return [description]
+ */
+Err
+update_main_from_fd(UUID main_id, char *updater, char *update_ip, int len, int fd_content, UUID content_id)
+{
+    Err error_code = S_OK;
+    int n_line;
+    int n_block;
+
+    time64_t update_milli_timestamp;
+
+    error_code = get_milli_timestamp(&update_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = gen_content_uuid_with_db(MONGO_MAIN_CONTENT, content_id);
+    if (error_code) return error_code;
+
+    // main-contents
+    error_code = split_contents_from_fd(fd_content, len, main_id, content_id, MONGO_MAIN_CONTENT, &n_line, &n_block);
+    if (error_code) return error_code;
+
+    // db-main
+    bson_t *main_id_bson = NULL;
+    bson_t *main_bson = NULL;
+
+    error_code = _serialize_uuid_bson(main_id, &main_id_bson);
+
+    // update: content_id, update_content_id, updater, update_ip, update_milli_timestamp, n_total_line, n_total_block, len_total
+    if(!error_code) {
+        error_code = _serialize_update_main_bson(content_id, updater, update_ip, update_milli_timestamp, n_line, n_block, len, &main_bson);
+    }
+
+    if(!error_code) {
+        error_code = db_update_one(MONGO_MAIN, main_id_bson, main_bson, false);
+    }
+
+    bson_safe_destroy(&main_bson);
+    bson_safe_destroy(&main_id_bson);
+
+    return error_code;
+}
+
+/**
+ * @brief Serialize main-header to bson
+ * @details Serialize main-header to bson
+ *
+ * @param main_header main-header
+ * @param main_bson main_bson (to-compute)
+ * @return Err
+ */
+Err
+_serialize_main_bson(MainHeader *main_header, bson_t **main_bson)
+{
+    *main_bson = BCON_NEW(
+        "version", BCON_INT32(main_header->version),
+        "the_id", BCON_BINARY(main_header->the_id, UUIDLEN),
+        "content_id", BCON_BINARY(main_header->content_id, UUIDLEN),
+        "update_content_id", BCON_BINARY(main_header->update_content_id, UUIDLEN),
+        "aid", BCON_INT64(main_header->aid),
+        "status", BCON_INT32(main_header->status),
+        "status_updater", BCON_BINARY((unsigned char *)main_header->status_updater, IDLEN),
+        "status_update_ip", BCON_BINARY((unsigned char *)main_header->status_update_ip, IPV4LEN),
+        "board", BCON_BINARY((unsigned char *)main_header->board, IDLEN),
+        "title", BCON_BINARY((unsigned char *)main_header->title, TTLEN),
+        "poster", BCON_BINARY((unsigned char *)main_header->poster, IDLEN),
+        "ip", BCON_BINARY((unsigned char *)main_header->ip, IPV4LEN),
+        "create_milli_timestamp", BCON_INT64(main_header->create_milli_timestamp),
+        "updater", BCON_BINARY((unsigned char *)main_header->updater, IDLEN),
+        "update_ip", BCON_BINARY((unsigned char *)main_header->update_ip,IPV4LEN),
+        "update_milli_timestamp", BCON_INT64(main_header->update_milli_timestamp),
+        "origin", BCON_BINARY((unsigned char *)main_header->origin, strlen(main_header->origin)),
+        "web_link", BCON_BINARY((unsigned char *)main_header->web_link, strlen(main_header->web_link)),
+        "reset_karma", BCON_INT32(main_header->reset_karma),
+        "n_total_line", BCON_INT32(main_header->n_total_line),
+        "n_total_block", BCON_INT32(main_header->n_total_block),
+        "len_total", BCON_INT32(main_header->len_total)
+        );
+    if(*main_bson == NULL) return S_ERR;
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param main_bson [description]
+ * @param main_header [description]
+ *
+ * @return Err
+ */
+Err
+_deserialize_main_bson(bson_t *main_bson, MainHeader *main_header)
+{    
+    char *str = bson_as_canonical_extended_json(main_bson, NULL);
+    fprintf(stderr, "pttdb_main._deserialze_main_bson: start: main_bson: %s\n", str);
+    bson_free(str);
+
+    Err error_code;
+    error_code = bson_get_value_int32(main_bson, "version", (int *)&main_header->version);
+    if (error_code) return error_code;
+
+    int len;
+    error_code = bson_get_value_bin(main_bson, "the_id", UUIDLEN, (char *)main_header->the_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "content_id", UUIDLEN, (char *)main_header->content_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "update_content_id", UUIDLEN, (char *)main_header->update_content_id, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(main_bson, "aid", (long *)&main_header->aid);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(main_bson, "status", (int *)&main_header->status);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "status_updater", IDLEN, main_header->status_updater, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "status_update_ip", IPV4LEN, main_header->status_update_ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "board", IDLEN, main_header->board, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "title", TTLEN, main_header->title, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "poster", IDLEN, main_header->poster, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "ip", IPV4LEN, main_header->ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(main_bson, "create_milli_timestamp", (long *)&main_header->create_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "updater", IDLEN, main_header->updater, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "update_ip", IPV4LEN, main_header->update_ip, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int64(main_bson, "update_milli_timestamp", (long *)&main_header->update_milli_timestamp);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "origin", MAX_ORIGIN_LEN, main_header->origin, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_bin(main_bson, "web_link", MAX_WEB_LINK_LEN, main_header->web_link, &len);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(main_bson, "reset_karma", &main_header->reset_karma);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(main_bson, "n_total_line", &main_header->n_total_line);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(main_bson, "n_total_block", &main_header->n_total_block);
+    if (error_code) return error_code;
+
+    error_code = bson_get_value_int32(main_bson, "len_total", &main_header->len_total);
+    if (error_code) return error_code;
+
+    return S_OK;
+}
+
+/**
+ * @brief [brief description]
+ * @details [long description]
+ *
+ * @param content_id [description]
+ * @param updater [description]
+ * @param p [description]
+ * @param update_milli_timestamp [description]
+ * @param n_total_line [description]
+ * @param n_total_block [description]
+ * @param len_total [description]
+ * @param main_bson [description]
+ */
+Err
+_serialize_update_main_bson(UUID content_id, char *updater, char *update_ip, time64_t update_milli_timestamp, int n_total_line, int n_total_block, int len_total, bson_t **main_bson)
+{
+    *main_bson = BCON_NEW(
+        "content_id", BCON_BINARY(content_id, UUIDLEN),
+        "updater", BCON_BINARY((unsigned char *)updater, IDLEN),
+        "update_ip", BCON_BINARY((unsigned char *)update_ip, IPV4LEN),
+        "update_milli_timestamp", BCON_INT64(update_milli_timestamp),
+        "n_total_line", BCON_INT32(n_total_line),
+        "n_total_block", BCON_INT32(n_total_block),
+        "len_total", BCON_INT32(len_total)
+        );
+    if(*main_bson == NULL) return S_ERR;
+
+    return S_OK;
+}

--- a/mbbsd/pttdb_misc.c
+++ b/mbbsd/pttdb_misc.c
@@ -1,0 +1,286 @@
+#include "pttdb.h"
+#include "pttdb_internal.h"
+
+/**********
+ * Milli-timestamp
+ **********/
+
+/**
+ * @brief Get current time in milli-timestamp
+ * @details Get current time in milli-timestamp
+ *
+ * @param milli_timestamp milli-timestamp (to-compute)
+ * @return Err
+ */
+Err
+get_milli_timestamp(time64_t *milli_timestamp)
+{
+    struct timeval tv;
+    struct timezone tz;
+
+    int ret_code = gettimeofday(&tv, &tz);
+    if (ret_code) return S_ERR;
+
+    *milli_timestamp = ((time64_t)tv.tv_sec) * 1000L + ((time64_t)tv.tv_usec) / 1000L;
+
+    return S_OK;
+}
+
+/**********
+ * UUID
+ **********/
+
+/**
+ * @brief Generate customized uuid (maybe we can use libuuid to save some random thing.)
+ * @details Generate customized uuid (ASSUMING little endian in the system):
+ *          1. byte[0-6]: random
+ *          2. byte[7]: 0x60 as version
+ *          3. byte[8-9]: random
+ *          4: byte[10-15]: milli-timestamp
+ *
+ * @param uuid [description]
+ */
+Err
+gen_uuid(UUID uuid)
+{
+    Err error_code;
+
+    time64_t milli_timestamp;
+    time64_t *p_milli_timestamp;
+
+    long int rand_num;
+    long int *p_rand;
+    unsigned short *p_short_rand_num;
+
+    unsigned short *p_short;
+    unsigned char *p_char;
+    _UUID _uuid;
+
+    // last 8 chars as milli-timestamp, but only the last 6 chars will be used.
+    error_code = get_milli_timestamp(&milli_timestamp);
+    if (error_code) return error_code;
+
+    milli_timestamp <<= 16;
+    p_char = (unsigned char *)&milli_timestamp;
+
+    p_milli_timestamp = (time64_t *)(_uuid + 40);
+    *p_milli_timestamp = milli_timestamp;
+
+    rand_num = random();
+    p_short_rand_num = (unsigned short *)&rand_num;
+    p_short = (unsigned short*)(_uuid + 40);
+    *p_short = *p_short_rand_num;
+
+    // first 40 chars as random, but 6th char is version (6 for now)
+    p_rand = (long int *)_uuid;
+    for (int i = 0; i < (_UUIDLEN - 8) / (int)sizeof(long int); i++) {
+        rand_num = random();
+        *p_rand = rand_num;
+        p_rand++;
+    }
+
+    _uuid[6] &= 0x0f;
+    _uuid[6] |= 0x60;
+
+    b64_ntop(_uuid, _UUIDLEN, (char *)uuid, UUIDLEN);
+
+    return S_OK;
+}
+
+/**
+ * @brief Gen uuid and check with db.
+ * @details Gen uuid and check with db for uniqueness.
+ *
+ * @param collection Collection
+ * @param uuid uuid (to-compute).
+ * @return Err
+ */
+Err
+gen_uuid_with_db(int collection, UUID uuid)
+{
+    Err error_code = S_OK;
+    bson_t *uuid_bson = NULL;
+
+    for (int i = 0; i < N_GEN_UUID_WITH_DB; i++) {
+        error_code = gen_uuid(uuid);
+
+        if(!error_code) {
+            error_code = _serialize_uuid_bson(uuid, &uuid_bson);
+        }
+
+        if(!error_code) {
+            error_code = db_set_if_not_exists(collection, uuid_bson);
+        }
+
+        bson_safe_destroy(&uuid_bson);
+
+        if (!error_code) return S_OK;
+    }
+
+    return error_code;
+}
+
+/**
+ * @brief Gen uuid with block-id as 0 and check with db.
+ * @details Gen uuid and check with db for uniqueness.
+ *
+ * @param collection Collection
+ * @param uuid uuid (to-compute).
+ * @return Err
+ */
+Err
+gen_content_uuid_with_db(int collection, UUID uuid)
+{
+    Err error_code = S_OK;
+    bson_t *uuid_bson = NULL;
+
+    for (int i = 0; i < N_GEN_UUID_WITH_DB; i++) {
+        error_code = gen_uuid(uuid);
+
+        if(!error_code) {
+            error_code = _serialize_content_uuid_bson(uuid, 0, &uuid_bson);
+        }
+
+        if(!error_code) {
+            error_code = db_set_if_not_exists(collection, uuid_bson);
+        }
+
+        bson_safe_destroy(&uuid_bson);
+
+        if (!error_code) return S_OK;
+    }
+
+    return error_code;
+}
+
+/**
+ * @brief Serialize uuid to bson
+ * @details Serialize uuid to bson, and name the uuid as the_id.
+ *
+ * @param uuid uuid
+ * @param db_set_bson bson (to-compute)
+ * @return Err
+ */
+Err
+_serialize_uuid_bson(UUID uuid, bson_t **uuid_bson)
+{
+    *uuid_bson = BCON_NEW(
+        MONGO_THE_ID, BCON_BINARY(uuid, UUIDLEN)
+        );
+
+    return S_OK;
+}
+
+/**
+ * @brief Serialize uuid to bson
+ * @details Serialize uuid to bson, and name the uuid as the_id.
+ *
+ * @param uuid uuid
+ * @param db_set_bson bson (to-compute)
+ * @return Err
+ */
+Err
+_serialize_content_uuid_bson(UUID uuid, int block_id, bson_t **uuid_bson)
+{
+    *uuid_bson = BCON_NEW(
+        MONGO_THE_ID, BCON_BINARY(uuid, UUIDLEN),
+        MONGO_BLOCK_ID, BCON_INT32(block_id)
+        );
+
+    return S_OK;
+}
+
+Err
+uuid_to_milli_timestamp(UUID uuid, time64_t *milli_timestamp)
+{
+    _UUID _uuid;
+    time64_t *p_uuid = (time64_t *)(_uuid + 40);
+    b64_pton((char *)uuid, _uuid, _UUIDLEN);
+
+    *milli_timestamp = *p_uuid;
+    *milli_timestamp >>= 16;
+
+    return S_OK;
+}
+
+/**********
+ * Get line from buf
+ **********/
+
+/**
+ * @brief Try to get a line (ending with \r\n) from buffer.
+ * @details [long description]
+ *
+ * @param p_buf Starting point of the buffer.
+ * @param offset_buf Current offset of the p_buf in the whole buffer.
+ * @param bytes Total bytes of the buffer.
+ * @param p_line Starting point of the line.
+ * @param offset_line Offset of the line.
+ * @param bytes_in_new_line To be obtained bytes in new extracted line.
+ * @return Error
+ */
+Err
+get_line_from_buf(char *p_buf, int offset_buf, int bytes, char *p_line, int offset_line, int *bytes_in_new_line)
+{
+
+    // check the end of buf
+    if (offset_buf >= bytes) {
+        *bytes_in_new_line = 0;
+
+        return S_ERR;
+    }
+
+    // init p_buf offset
+    p_buf += offset_buf;
+    p_line += offset_line;
+
+    // check bytes in line and in buf.
+    if (offset_line && p_line[-1] == '\r' && p_buf[0] == '\n') {
+        *p_line = '\n';
+        *bytes_in_new_line = 1;
+
+        return S_OK;
+    }
+
+    // check \r\n in buf.
+    int max_new_lines = MAX_BUF_SIZE - offset_line;
+    int iter_bytes = (bytes - offset_buf <= max_new_lines) ? (bytes - offset_buf) : max_new_lines;
+    int end_bytes = iter_bytes + offset_buf;
+    for (int i = offset_buf; i < end_bytes - 1; i++) {
+        if (*p_buf == '\r' && *(p_buf + 1) == '\n') {
+            *p_line = '\r';
+            *(p_line + 1) = '\n';
+            *bytes_in_new_line = i - offset_buf + 1 + 1;
+
+            return S_OK;
+        }
+
+        *p_line++ = *p_buf++;
+    }
+
+    // last char
+    *p_line++ = *p_buf++;
+    *bytes_in_new_line = end_bytes - offset_buf;
+
+    fprintf(stderr, "pttdb_misc.get_line_from_buf: offset_line: %d max_new_lines: %d bytes: %d iter_bytes: %d end_bytes: %d offset_buf: %d bytes_in_new_line: %d\n", offset_line, max_new_lines, bytes, iter_bytes, end_bytes, offset_buf, *bytes_in_new_line);
+
+    // XXX special case for all block as a continuous string. Although it's not end yet, it forms a block.
+    if(*bytes_in_new_line == max_new_lines) return S_OK;
+
+    return S_ERR;
+}
+
+Err
+pttdb_count_lines(char *content, int len, int *n_line)
+{
+    int tmp_n_line = 0;
+    char *p_content = content;
+    for(int i = 0; i < len - 1; i++, p_content++) {
+        if(*p_content == '\r' && *(p_content + 1) == '\n') {
+            tmp_n_line++;
+        }
+    }
+    *n_line = tmp_n_line;
+
+    return S_OK;
+}

--- a/mbbsd/util_db.c
+++ b/mbbsd/util_db.c
@@ -1,0 +1,496 @@
+#include "bbs.h"
+#include "util_db.h"
+#include "util_db_internal.h"
+
+const char *DEFAULT_MONGO_DB[] = {
+    "post",      //MONGO_POST_DBNAME
+    "test",      //MONGO_TEST_DBNAME
+};
+
+/**********
+ * Globally Available
+ **********/
+mongoc_uri_t *MONGO_URI = NULL;
+mongoc_client_pool_t *MONGO_CLIENT_POOL = NULL;
+
+/**********
+ * In-thread Available
+ **********/
+mongoc_client_t *MONGO_CLIENT = NULL;
+mongoc_collection_t **MONGO_COLLECTIONS = NULL;
+
+/**********
+ * Mongo
+ **********/
+
+/**
+ * @brief Init mongo global variables
+ * @details mongo-init, mongo-uri, and mongo-client-pool
+ */
+Err
+init_mongo_global()
+{
+    mongoc_init();
+
+    MONGO_URI = mongoc_uri_new(MONGO_CLIENT_URL);
+    if (!MONGO_URI) return S_ERR;
+
+    MONGO_CLIENT_POOL = mongoc_client_pool_new(MONGO_URI);
+    mongoc_client_pool_set_error_api(MONGO_CLIENT_POOL, MONGOC_ERROR_API_VERSION_2);
+
+    return S_OK;
+}
+
+/**
+ * @brief Free mongo global variables
+ * @details mongo-client-pool, mongo-uri, and mongo-cleanup.
+ */
+Err
+free_mongo_global()
+{
+    if(MONGO_CLIENT_POOL) {
+        mongoc_client_pool_destroy(MONGO_CLIENT_POOL);
+        MONGO_CLIENT_POOL = NULL;
+    }
+
+    if(MONGO_URI) {
+        mongoc_uri_destroy(MONGO_URI);
+        MONGO_URI = NULL;
+    }
+
+    mongoc_cleanup();
+
+    return S_OK;
+}
+
+/**
+ * @brief Init collections (per thread)
+ * @details client, collections.
+ */
+Err
+init_mongo_collections(const char *db_name[])
+{
+    if (db_name == NULL) {
+        db_name = DEFAULT_MONGO_DB;
+    }
+
+    MONGO_CLIENT = mongoc_client_pool_try_pop(MONGO_CLIENT_POOL);
+    if (MONGO_CLIENT == NULL) {
+        return S_ERR;
+    }
+
+    MONGO_COLLECTIONS = malloc(sizeof(mongoc_collection_t *) * N_MONGO_COLLECTIONS);
+    MONGO_COLLECTIONS[MONGO_MAIN] = mongoc_client_get_collection(MONGO_CLIENT, db_name[MONGO_POST_DBNAME], MONGO_MAIN_NAME);
+    MONGO_COLLECTIONS[MONGO_MAIN_CONTENT] = mongoc_client_get_collection(MONGO_CLIENT, db_name[MONGO_POST_DBNAME], MONGO_MAIN_CONTENT_NAME);
+    MONGO_COLLECTIONS[MONGO_COMMENT] = mongoc_client_get_collection(MONGO_CLIENT, db_name[MONGO_POST_DBNAME], MONGO_COMMENT_NAME);
+    MONGO_COLLECTIONS[MONGO_COMMENT_REPLY] = mongoc_client_get_collection(MONGO_CLIENT, db_name[MONGO_POST_DBNAME], MONGO_COMMENT_REPLY_NAME);
+
+    MONGO_COLLECTIONS[MONGO_TEST] = mongoc_client_get_collection(MONGO_CLIENT, db_name[MONGO_TEST_DBNAME], MONGO_TEST_NAME);
+
+    return S_OK;
+}
+
+/**
+ * @brief Free collections (per thread)
+ *        XXX Need to check what happened if we use fork.
+ * @details collections, client.
+ */
+Err
+free_mongo_collections()
+{
+    // mongo-collections
+    if(!MONGO_COLLECTIONS) return S_OK;
+
+    for (int i = 0; i < N_MONGO_COLLECTIONS; i++) {
+        mongoc_collection_destroy(MONGO_COLLECTIONS[i]);
+    }
+    free(MONGO_COLLECTIONS);
+    MONGO_COLLECTIONS = NULL;
+
+    // mongo-client
+    if(!MONGO_CLIENT) return S_OK;
+
+    mongoc_client_pool_push(MONGO_CLIENT_POOL, MONGO_CLIENT);
+    MONGO_CLIENT = NULL;
+
+    return S_OK;
+}
+
+/**
+ * @brief set if not exists
+ * @details [long description]
+ *
+ * @param collection [description]
+ * @param key [description]
+ */
+Err
+db_set_if_not_exists(int collection, bson_t *key)
+{
+    Err error_code = S_OK;
+
+    bool status;
+
+    bson_t *set_val = BCON_NEW("$setOnInsert", BCON_DOCUMENT(key));
+    bson_t *opts = BCON_NEW("upsert", BCON_BOOL(true));
+
+    bool is_upserted_id_exist;
+
+
+    // reply
+    if(!error_code) {
+        bson_t reply;
+        bson_error_t error;
+
+        status = mongoc_collection_update_one(MONGO_COLLECTIONS[collection], key, set_val, opts, &reply, &error);
+        if (!status) error_code = S_ERR;
+
+        bson_exists(&reply, "upsertedId", &is_upserted_id_exist);
+
+        bson_destroy(&reply);
+    }
+
+    if(!error_code) {
+        if (!is_upserted_id_exist) error_code = S_ERR_ALREADY_EXISTS;
+    }
+
+    bson_destroy(set_val);
+    bson_destroy(opts);
+
+    return error_code;
+}
+
+/**
+ * @brief update one key / val
+ * @details [long description]
+ *
+ * @param collection [description]
+ * @param key [description]
+ * @param val [description]
+ * @param is_upsert [description]
+ */
+Err
+db_update_one(int collection, bson_t *key, bson_t *val, bool is_upsert)
+{
+    Err error_code = S_OK;
+    bool status;
+
+    bson_t *set_val = BCON_NEW("$set", BCON_DOCUMENT(val));
+    bson_t *opts = BCON_NEW("upsert", BCON_BOOL(is_upsert));
+
+    bson_t reply;
+    bson_error_t error;
+
+    status = mongoc_collection_update_one(MONGO_COLLECTIONS[collection], key, set_val, opts, &reply, &error);
+    if (!status) error_code = S_ERR;
+    bson_destroy(&reply);
+
+    bson_destroy(set_val);
+    bson_destroy(opts);
+
+    return error_code;
+}
+
+/**
+ * @brief find one result in db
+ * @details
+ *          Example:
+ *                bson_t *key = BCON_NEW("a", BCON_BINARY("test", 4));
+ *                bson_t *result = NULL;
+ *                db_find_one(collection, key, NULL, &result);
+ *                
+ *                if(result) {
+ *                    bson_destroy(result);
+ *                }
+ *
+ * @param collection [description]
+ * @param key [description]
+ * @param fields [description]
+ * @param result result (MUST-NOT initialized and need to bson_destroy)
+ */
+Err
+db_find_one(int collection, bson_t *key, bson_t *fields, bson_t **result)
+{
+    int n_results;
+    return db_find(collection, key, fields, NULL, 1, &n_results, result);
+}
+
+
+Err
+db_find(int collection, bson_t *key, bson_t *fields, bson_t *sort, int max_n_results, int *n_results, bson_t **results)
+{
+    Err error_code = S_OK;
+
+    bool status;
+
+    bson_t *opts = BCON_NEW("limit", BCON_INT64(max_n_results));
+    if(fields) {
+        status = bson_append_document(opts, "projection", -1, fields);
+        if(!status) error_code = S_ERR;
+    }
+    if(sort) {
+        status = bson_append_document(opts, "sort", -1, sort);
+        if(!status) error_code = S_ERR;        
+    }
+
+    if(!error_code) {
+        mongoc_cursor_t *cursor = mongoc_collection_find_with_opts(MONGO_COLLECTIONS[collection], key, opts, NULL);
+        bson_error_t error;
+
+        const bson_t *p_result;
+        int len = 0;
+        while (mongoc_cursor_next(cursor, &p_result)) {
+            *results = bson_copy(p_result);
+            results++;
+            len++;
+        }
+        *n_results = len;
+
+        if (mongoc_cursor_error(cursor, &error)) {
+            error_code = S_ERR;
+        }
+
+        mongoc_cursor_destroy(cursor);        
+    }    
+
+    if(!error_code) {
+        if (*n_results == 0) error_code = S_ERR_NOT_EXISTS;
+    }
+
+    bson_destroy(opts);
+
+    return error_code;
+}
+
+Err
+db_remove(int collection, bson_t *key)
+{
+    Err error_code = S_OK;
+    bson_error_t error;
+    bool status;
+
+    status = mongoc_collection_delete_many(MONGO_COLLECTIONS[collection], key, NULL, NULL, &error);
+    if(!status) error_code = S_ERR;
+
+    return error_code;
+}
+
+Err
+db_aggregate(int collection, bson_t *pipeline, int max_n_results, bson_t **results, int *n_results)
+{
+    Err error_code = S_OK;
+    const bson_t *doc = NULL;
+
+    mongoc_cursor_t *cursor = mongoc_collection_aggregate(MONGO_COLLECTIONS[collection], MONGOC_QUERY_NONE, pipeline, NULL, NULL);
+
+    int tmp_n_results = 0;
+    bson_t **p_results = results;
+    while(tmp_n_results < max_n_results) {
+        if(!mongoc_cursor_next(cursor, &doc)) break;
+
+        *p_results = bson_copy(doc);
+        p_results++;
+        tmp_n_results++;
+    }
+
+    *n_results = tmp_n_results;
+
+    bson_error_t error;
+    if (mongoc_cursor_error (cursor, &error)) {
+        error_code = S_ERR;
+    }
+
+    mongoc_cursor_destroy(cursor);
+
+    return error_code;
+}
+
+Err
+db_count(int collection, bson_t *key, int *count)
+{
+    Err error_code = S_OK;
+    bson_error_t error;
+    int64_t tmp_count = mongoc_collection_count_with_opts(MONGO_COLLECTIONS[collection], MONGOC_QUERY_NONE, key, 0, 0, NULL, NULL, &error);
+
+    if(tmp_count == -1) {
+        error_code = S_ERR;
+        tmp_count = 0;
+    }
+
+    *count = (int)tmp_count;
+
+    return error_code;
+}
+
+Err
+_DB_FORCE_DROP_COLLECTION(int collection)
+{
+    bool status;
+    bson_error_t error;
+    status = mongoc_collection_drop(MONGO_COLLECTIONS[collection], &error);
+    if (!status) return S_ERR;
+
+    return S_OK;
+}
+
+/**
+ * @brief exists the name in the bson-struct
+ * @details [long description]
+ *
+ * @param b the bson-struct
+ * @param name name
+ */
+Err
+bson_exists(bson_t *b, char *name, bool *is_exist)
+{
+    bool status;
+    bson_iter_t iter;
+
+    status = bson_iter_init_find(&iter, b, name);
+    if (!status) {
+        *is_exist = false;
+    }
+    else  {
+        *is_exist = true;
+    }
+
+    return S_OK;
+}
+
+/**
+ * @brief get int32 value in bson
+ * @details [long description]
+ *
+ * @param b [description]
+ * @param name [description]
+ * @param value [description]
+ */
+Err
+bson_get_value_int32(bson_t *b, char *name, int *value)
+{
+    bool status;
+    bson_iter_t iter;
+
+    status = bson_iter_init_find(&iter, b, name);
+    if (!status) return S_ERR;
+
+    status = BSON_ITER_HOLDS_INT32(&iter);
+    if (!status) return S_ERR;
+
+    *value = bson_iter_int32(&iter);
+
+    return S_OK;
+}
+
+/**
+ * @brief get int64 value in bson
+ * @details [long description]
+ *
+ * @param b [description]
+ * @param name [description]
+ * @param value [description]
+ */
+Err
+bson_get_value_int64(bson_t *b, char *name, long int *value)
+{
+    bool status;
+    bson_iter_t iter;
+
+    status = bson_iter_init_find(&iter, b, name);
+    if (!status) return S_ERR;
+
+    status = BSON_ITER_HOLDS_INT64(&iter);
+    if (!status) return S_ERR;
+
+    *value = bson_iter_int64(&iter);
+
+    return S_OK;
+}
+
+/**
+ * @brief find binary in the bson-struct
+ * @details [long description]
+ *
+ * @param b [description]
+ * @param name [description]
+ * @param value [MUST-NOT initialized and need to free!]
+ * @param len received length
+ */
+Err
+bson_get_value_bin_not_initialized(bson_t *b, char *name, char **value, int *p_len)
+{
+    bool status;
+    bson_subtype_t subtype;
+    bson_iter_t iter;
+
+    status = bson_iter_init_find(&iter, b, name);
+    if (!status) return S_ERR;
+
+    status = BSON_ITER_HOLDS_BINARY(&iter);
+    if (!status) return S_ERR;
+
+    const char *p_value;
+    int tmp_len;
+    bson_iter_binary(&iter, &subtype, (unsigned int *)&tmp_len, (const unsigned char **)&p_value);
+
+    *value = malloc(tmp_len + 1);
+    if(!value) return S_ERR;
+
+    memcpy(*value, p_value, tmp_len);
+    (*value)[tmp_len] = 0;
+    *p_len = tmp_len;
+
+    return S_OK;
+}
+
+/**
+ * @brief get binary value without init
+ * @details [long description]
+ *
+ * @param b [description]
+ * @param name [description]
+ * @param max_len max-length of the buffer
+ * @param value [MUST INITIALIZED WITH max_len!]
+ * @param len real received length
+ */
+Err
+bson_get_value_bin(bson_t *b, char *name, int max_len, char *value, int *p_len)
+{    
+    Err error = S_OK;
+
+    bool status;
+    bson_subtype_t subtype;
+    bson_iter_t iter;
+
+    status = bson_iter_init_find(&iter, b, name);
+    if (!status) return S_ERR;
+
+    status = BSON_ITER_HOLDS_BINARY(&iter);
+    if (!status) return S_ERR;
+
+    char *p_value;
+    bson_iter_binary(&iter, &subtype, (unsigned int *)p_len, (const unsigned char **)&p_value);
+
+    int tmp_len = *p_len;
+    if (tmp_len > max_len) {
+        tmp_len = max_len;
+        error = S_ERR_BUFFER_LEN;
+    }
+
+    memcpy(value, p_value, tmp_len);
+    if (tmp_len < max_len) {
+        value[tmp_len + 1] = 0;
+    }
+
+    return error;
+}
+
+Err
+bson_safe_destroy(bson_t **b)
+{
+    if(*b == NULL) return S_OK;
+
+    bson_destroy(*b);
+    *b = NULL;
+
+    return S_OK;
+}

--- a/sample/pttbbs.conf
+++ b/sample/pttbbs.conf
@@ -276,3 +276,5 @@
 /* 前進站畫面 */
 #define INSCREEN \
 "前進站畫面 (請至 pttbbs.conf 修改您的前進站畫面)"
+
+//#define MONGO_CLIENT_URL "mongodb://localhost/?wtimeoutms=30000&serverselectiontimeoutms=10000"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,3 @@
+SUBDIR:= test_mbbsd
+
+.include <bsd.subdir.mk>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+Unit-Test
+===========
+
+這個 unit-test 是 based on googletest. 在 ubuntu 裡使用 libgtest-dev.
+
+Setup (在 ubuntu 16.04 裡)
+-----
+1. `apt-get install -y libgtest-dev`
+
+2. 在 pttbbs 做 `make GTEST_DIR=/usr/src/gtest`

--- a/tests/test_mbbsd/Makefile
+++ b/tests/test_mbbsd/Makefile
@@ -1,0 +1,126 @@
+# $Id$
+
+##########
+# use googletest as test-framework
+##########
+
+SRCROOT:= ../..
+.include "$(SRCROOT)/pttbbs.mk"
+
+MBBSD_DIR:=	${SRCROOT}/mbbsd
+
+##########
+# gtest
+##########
+
+CPPFLAGS+=	-isystem $(GTEST_DIR)/include
+CXXFLAGS+=	-g -Wall -Wextra -pthread
+
+GTEST_HEADERS=	/usr/include/gtest/*.h \
+		/usr/include/gtest/internal/*.h
+
+GTEST_SRCS_= $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
+
+AR:=		ar
+ARFLAGS:=	rv
+
+#######################################################################
+# mbbsd modules
+#######################################################################
+MBBSD_OBJS:=
+
+#######################################################################
+# reduce .bss align overhead
+#######################################################################
+
+.if !defined(DEBUG) && $(OSTYPE)!="Darwin"
+LDFLAGS+=-Wl,--sort-common
+.endif
+
+#######################################################################
+# common libraries
+#######################################################################
+
+LDFLAGS+= -L$(SRCROOT)/common/bbs -L$(SRCROOT)/common/sys \
+	  -L$(SRCROOT)/common/osdep
+LDLIBS:= -lcmbbs -lcmsys -losdep $(LDLIBS)
+
+#######################################################################
+# conditional configurations and optional modules
+#######################################################################
+
+BBSCONF:=	$(SRCROOT)/pttbbs.conf
+DEF_PATTERN:=	^[ \t]*\#[ \t]*define[ \t]*
+DEF_CMD:=	grep -Ewq "${DEF_PATTERN}"
+DEF_YES:=	&& echo "YES" || echo ""
+USE_BBSLUA!=  	sh -c '${DEF_CMD}"USE_BBSLUA" ${BBSCONF} ${DEF_YES}'
+USE_PFTERM!=	sh -c '${DEF_CMD}"USE_PFTERM" ${BBSCONF} ${DEF_YES}'
+USE_NIOS!=	sh -c '${DEF_CMD}"USE_NIOS"   ${BBSCONF} ${DEF_YES}'
+USE_CONVERT!=	sh -c '${DEF_CMD}"CONVERT"    ${BBSCONF} ${DEF_YES}'
+MONGO_CLIENT_URL!=	sh -c '${DEF_CMD}"MONGO_CLIENT_URL" ${BBSCONF} ${DEF_YES}'
+
+.if $(MONGO_CLIENT_URL)
+MONGO_CXXFLAGS:=	-I/usr/local/include/libmongoc-1.0 -I/usr/local/include/libbson-1.0	
+MONGO_LDFLAGS:= -L/usr/local/lib -Wl,-rpath,/usr/local/lib -rdynamic
+MONGO_LIBS:=	-lmongoc-1.0 -lbson-1.0 -lresolv
+CXXFLAGS+=	${MONGO_CXXFLAGS}
+LDFLAGS+=	${MONGO_LDFLAGS}
+LDLIBS+=	${MONGO_LIBS}
+MBBSD_OBJS+=	${MBBSD_DIR}/pttdb.o ${MBBSD_DIR}/pttdb_main.o ${MBBSD_DIR}/pttdb_comment.o ${MBBSD_DIR}/pttdb_comment_reply.o ${MBBSD_DIR}/pttdb_content_block.o ${MBBSD_DIR}/pttdb_misc.o ${MBBSD_DIR}/util_db.o
+.endif # MONGO_CLIENT_URL
+
+##########
+# test
+##########
+
+TEST_PROGS=	test_dummy
+
+.if $(MONGO_CLIENT_URL)
+TEST_PROGS+=	test_pttdb test_pttdb_main test_pttdb_comment test_pttdb_comment_reply test_pttdb_content_block test_pttdb_misc test_util_db
+.endif
+
+##########
+# TARGETS
+##########
+
+.if defined(GTEST_DIR)
+##########
+# gtest
+##########
+gtest-all.o: $(GTEST_SRCS_)
+	$(CXX) -I$(GTEST_DIR) $(CXXFLAGS) -c $(GTEST_DIR)/src/gtest-all.cc
+
+gtest_main.o: $(GTEST_SRCS_)
+	$(CXX) -I$(GTEST_DIR) $(CXXFLAGS) -c $(GTEST_DIR)/src/gtest_main.cc
+
+gtest.a: gtest-all.o
+	$(AR) $(ARFLAGS) $@ $>
+
+gtest_main.a: gtest-all.o gtest_main.o
+	$(AR) $(ARFLAGS) $@ $>
+
+##########
+# all
+##########
+
+.SUFFIXES: .cc .o
+
+.cc.o: $(SRCROOT)/include/var.h
+	$(CXX) $(CXXFLAGS) -c $*.cc
+
+.for fn in ${TEST_PROGS}
+${fn}: ${fn}.o gtest.a ${MBBSD_OBJS}
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $> $(LDLIBS)
+.endfor
+
+
+all: $(TEST_PROGS)
+
+.else # GTEST_DIR
+
+all:
+
+.endif # GTEST_DIR
+
+clean:
+	rm -f *.o gtest.a gtest_main.a $(TEST_PROGS)

--- a/tests/test_mbbsd/test_dummy.cc
+++ b/tests/test_mbbsd/test_dummy.cc
@@ -1,0 +1,27 @@
+#include "gtest/gtest.h"
+
+TEST(dummy, dummy) {
+    EXPECT_EQ(0, 0);
+}
+
+/**********
+ * MAIN
+ */
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+}
+
+void MyEnvironment::TearDown() {
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_pttdb.cc
+++ b/tests/test_mbbsd/test_pttdb.cc
@@ -1,0 +1,123 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "pttdb.h"
+#include "pttdb_internal.h"
+#include "util_db_internal.h"
+
+TEST(pttdb, n_line_post)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test1.txt", O_RDONLY);
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10020;
+    UUID main_id = {};
+    UUID content_id = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    // create-main-from-fd
+    Err error = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error);
+
+
+    close(fd);
+
+    // create-comment
+    UUID comment_id = {};
+    UUID comment_id2 = {};
+
+    error = create_comment(main_id, (char *)"poster1", (char *)"10.3.1.4", 10, (char *)"test1test1", COMMENT_TYPE_GOOD, comment_id);
+    EXPECT_EQ(S_OK, error);
+    error = create_comment(main_id, (char *)"poster1", (char *)"10.3.1.4", 10, (char *)"test2test2", COMMENT_TYPE_GOOD, comment_id2);
+
+    // comment-reply
+    UUID comment_reply_id = {};
+    UUID comment_reply_id2 = {};
+
+    error = create_comment_reply(main_id, comment_id, (char *)"poster1", (char *)"10.3.1.4", 24, (char *)"test1test1\r\ntest3test3\r\n", comment_reply_id);
+    EXPECT_EQ(S_OK, error);
+    error = create_comment_reply(main_id, comment_id2, (char *)"poster1", (char *)"10.3.1.4", 12, (char *)"test2test2\r\n", comment_reply_id2);
+    EXPECT_EQ(S_OK, error);
+
+    int n_line;
+    error = n_line_post(main_id, &n_line);
+    EXPECT_EQ(S_OK, error)    ;
+    EXPECT_EQ(15, n_line);
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_pttdb.err", O_WRONLY|O_CREAT|O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",
+        "test",
+    };
+
+    err = init_mongo_global();
+    if(err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if(err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+
+    FILE *f = fopen("data_test/test1.txt", "w");
+    for (int j = 0; j < 10; j++) {
+        for (int i = 0; i < 1000; i++) {
+            fprintf(f, "%c", 64 + (i % 26));
+        }
+        fprintf(f, "\r\n");
+    }
+    fclose(f);    
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+
+    if(FD) {
+        close(FD);
+        FD = 0;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_pttdb_comment.cc
+++ b/tests/test_mbbsd/test_pttdb_comment.cc
@@ -1,0 +1,1239 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "pttdb.h"
+#include "pttdb_internal.h"
+#include "util_db_internal.h"
+
+TEST(pttdb_comment, create_comment) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    UUID main_id;
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char content[] = "temp_content";
+    int len = strlen(content);
+    enum CommentType comment_type = COMMENT_TYPE_GOOD;
+
+    UUID comment_id;
+    UUID tmp_comment_id;
+
+    gen_uuid(main_id);
+    Err error_code = create_comment(main_id, poster, ip, len, content, comment_type, comment_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    Comment comment = {};
+    init_comment_buf(&comment);
+
+    memcpy(tmp_comment_id, comment_id, UUIDLEN);
+
+    error_code = read_comment(comment_id, &comment);
+    EXPECT_EQ(S_OK, error_code);
+
+    EXPECT_EQ(0, strncmp((char *)tmp_comment_id, (char *)comment.the_id, UUIDLEN));
+
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)comment.main_id, UUIDLEN));
+    EXPECT_EQ(LIVE_STATUS_ALIVE, comment.status);
+
+    EXPECT_STREQ(poster, comment.status_updater);
+    EXPECT_STREQ(ip, comment.status_update_ip);
+
+    EXPECT_EQ(comment_type, comment.comment_type);
+    EXPECT_EQ(KARMA_GOOD, comment.karma);
+
+    EXPECT_STREQ(poster, comment.poster);
+    EXPECT_STREQ(ip, comment.ip);
+
+    EXPECT_STREQ(poster, comment.updater);
+    EXPECT_STREQ(ip, comment.update_ip);
+
+    EXPECT_EQ(comment.create_milli_timestamp, comment.update_milli_timestamp);
+
+    EXPECT_EQ(len, comment.len);
+    EXPECT_STREQ(content, comment.buf);
+
+    destroy_comment(&comment);
+}
+
+TEST(pttdb_comment, delete_comment) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    UUID main_id;
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char content[] = "temp_content";
+    int len = strlen(content);
+    enum CommentType comment_type = COMMENT_TYPE_GOOD;
+
+    UUID comment_id;
+
+    gen_uuid(main_id);
+    Err error = create_comment(main_id, poster, ip, len, content, comment_type, comment_id);
+    EXPECT_EQ(S_OK, error);
+
+    char del_updater[IDLEN + 1] = "del_updater";
+    char status_update_ip[IPV4LEN + 1] = "10.1.1.4";
+    error = delete_comment(comment_id, del_updater, status_update_ip);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "status", BCON_BOOL(true),
+        "status_updater", BCON_BOOL(true),
+        "status_update_ip", BCON_BOOL(true)
+        );
+
+    bson_t *query = BCON_NEW(
+        "the_id", BCON_BINARY(comment_id, UUIDLEN)
+    );
+    bson_t *result = NULL;
+
+    error = db_find_one(MONGO_COMMENT, query, fields, &result);
+    EXPECT_EQ(S_OK, error);
+    int result_status;
+    char result_status_updater[MAX_BUF_SIZE];
+    char result_status_update_ip[MAX_BUF_SIZE];
+    bson_get_value_int32(result, (char *)"status", &result_status);
+    bson_get_value_bin(result, (char *)"status_updater", MAX_BUF_SIZE, result_status_updater, &len);
+    bson_get_value_bin(result, (char *)"status_update_ip", MAX_BUF_SIZE, result_status_update_ip, &len);
+
+    EXPECT_EQ(LIVE_STATUS_DELETED, result_status);
+    EXPECT_STREQ(del_updater, result_status_updater);
+    EXPECT_STREQ(status_update_ip, result_status_update_ip);
+
+    bson_safe_destroy(&query);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&result);
+}
+
+
+TEST(pttdb_comment, serialize_comment_bson) {
+    Comment comment = {};
+    Comment comment2 = {};
+
+    init_comment_buf(&comment);
+    init_comment_buf(&comment2);
+
+    comment.version = 2;
+    gen_uuid(comment.the_id);
+    gen_uuid(comment.main_id);
+    comment.status = LIVE_STATUS_ALIVE;
+
+    strcpy(comment.status_updater, "updater1");
+    strcpy(comment.status_update_ip, "10.3.1.4");
+
+    comment.comment_type = COMMENT_TYPE_GOOD;
+    comment.karma = KARMA_GOOD;
+
+    strcpy(comment.poster, "poster1");
+    strcpy(comment.ip, "10.3.1.5");
+    comment.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(comment.updater, "updater2");
+    strcpy(comment.update_ip, "10.3.1.6");
+    comment.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+
+    strcpy(comment.buf, "test_buf");
+    comment.len = strlen(comment.buf);
+
+    bson_t *comment_bson = NULL;
+
+    Err error = _serialize_comment_bson(&comment, &comment_bson);
+    EXPECT_EQ(S_OK, error);
+
+    char *str = bson_as_canonical_extended_json(comment_bson, NULL);
+    fprintf(stderr, "test_pttdb_comment.serialize_comment_bson: comment_bson: %s\n", str);
+    bson_free(str);
+
+    error = _deserialize_comment_bson(comment_bson, &comment2);
+
+    bson_safe_destroy(&comment_bson);
+
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(comment.version, comment2.version);
+    EXPECT_EQ(0, strncmp((char *)comment.the_id, (char *)comment2.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)comment.main_id, (char *)comment2.main_id, UUIDLEN));
+    EXPECT_EQ(comment.status, comment2.status);
+    EXPECT_STREQ(comment.status_updater, comment2.status_updater);
+    EXPECT_STREQ(comment.status_update_ip, comment2.status_update_ip);
+    EXPECT_EQ(comment.comment_type, comment2.comment_type);
+    EXPECT_EQ(comment.karma, comment2.karma);
+    EXPECT_STREQ(comment.poster, comment2.poster);
+    EXPECT_STREQ(comment.ip, comment2.ip);
+    EXPECT_EQ(comment.create_milli_timestamp, comment2.create_milli_timestamp);
+    EXPECT_STREQ(comment.updater, comment2.updater);
+    EXPECT_STREQ(comment.update_ip, comment2.update_ip);
+    EXPECT_EQ(comment.update_milli_timestamp, comment2.update_milli_timestamp);
+    EXPECT_EQ(comment.len, comment2.len);
+    EXPECT_STREQ(comment.buf, comment2.buf);
+
+    destroy_comment(&comment);
+    destroy_comment(&comment2);
+}
+
+TEST(pttdb_comment, get_comment_info_by_main) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    UUID main_id;
+    UUID comment_id;
+    UUID comment_id2;
+
+    gen_uuid(main_id);
+
+    Err error = S_OK;
+    error = create_comment(main_id, (char *)"poster1", (char *)"10.3.1.4", 10, (char *)"test1test1", COMMENT_TYPE_GOOD, comment_id);
+    EXPECT_EQ(S_OK, error);
+    error = create_comment(main_id, (char *)"poster1", (char *)"10.3.1.4", 10, (char *)"test2test2", COMMENT_TYPE_GOOD, comment_id2);
+    EXPECT_EQ(S_OK, error);
+
+    int n_total_comments = 0;
+    int total_len = 0;
+    error = get_comment_info_by_main(main_id, &n_total_comments, &total_len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(2, n_total_comments);
+    EXPECT_EQ(20, total_len);
+}
+
+TEST(pttdb_comment, get_comment_count_by_main) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    UUID main_id;
+    UUID comment_id;
+    UUID comment_id2;
+
+    gen_uuid(main_id);
+
+    Err error = S_OK;
+    error = create_comment(main_id, (char *)"poster1", (char *)"10.3.1.4", 10, (char *)"test1test1", COMMENT_TYPE_GOOD, comment_id);
+    EXPECT_EQ(S_OK, error);
+    error = create_comment(main_id, (char *)"poster1", (char *)"10.3.1.4", 10, (char *)"test2test2", COMMENT_TYPE_GOOD, comment_id2);
+    EXPECT_EQ(S_OK, error);
+
+    int n_total_comments = 0;
+    error = get_comment_count_by_main(main_id, &n_total_comments);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(2, n_total_comments);
+}
+
+TEST(pttdb_comment, ensure_db_results_order) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+    long int rand_int = 0;
+
+    for(int i = 0; i < n_results; i++) {
+        rand_int = random();
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)"test_poster", 11),
+                "create_milli_timestamp", BCON_INT64(rand_int)
+            );    
+    }
+
+    Err error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_ERR, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, ensure_db_results_order2) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+
+    for(int i = 0; i < n_results; i++) {
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)"test_poster", 11),
+                "create_milli_timestamp", BCON_INT64(i)
+            );    
+    }
+
+    Err error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_ERR, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, ensure_db_results_order3) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+
+    for(int i = 0; i < n_results; i++) {
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)"test_poster", 11),
+                "create_milli_timestamp", BCON_INT64(100 - i)
+            );    
+    }
+
+    Err error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_ERR, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, ensure_db_results_order4) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+
+    char poster[IDLEN + 1] = {};
+    for(int i = 0; i < n_results; i++) {
+        sprintf(poster, "poster%03d", i);
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)poster, IDLEN),
+                "create_milli_timestamp", BCON_INT64(100)
+            );    
+    }
+
+    Err error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_ERR, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, ensure_db_results_order5) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+
+    char poster[IDLEN + 1] = {};
+    for(int i = 0; i < n_results; i++) {
+        sprintf(poster, "poster%03d", 100 - i);
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)poster, IDLEN),
+                "create_milli_timestamp", BCON_INT64(100)
+            );    
+    }
+
+    Err error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_ERR, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, sort_db_results_order) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+    long int rand_int = 0;
+
+    for(int i = 0; i < n_results; i++) {
+        rand_int = random();
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)"test_poster", 11),
+                "create_milli_timestamp", BCON_INT64(rand_int)
+            );    
+    }
+
+    Err error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_OK, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, sort_db_results_order2) {
+    int n_results = 100;
+    bson_t **db_results = (bson_t **)malloc(sizeof(bson_t *) * n_results);
+    long int rand_int = 0;
+
+    char poster[IDLEN + 1] = {};
+    for(int i = 0; i < n_results; i++) {
+        rand_int = random();
+        sprintf(poster, "poster%03ld", rand_int);
+        db_results[i] = BCON_NEW(
+                "poster", BCON_BINARY((unsigned char *)poster, IDLEN),
+                "create_milli_timestamp", BCON_INT64(100)
+            );    
+    }
+
+    Err error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LT);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_GTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_ERR, error);
+
+    error = _sort_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_db_results_order(db_results, n_results, READ_COMMENTS_OP_TYPE_LTE);
+    EXPECT_EQ(S_OK, error);
+
+    for(int i = 0; i < n_results; i++) {
+        bson_safe_destroy(&db_results[i]);
+    }
+    free(db_results);
+}
+
+TEST(pttdb_comment, read_comments_by_main)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    char poster[IDLEN + 1] = {};
+    int n_comments = 100;
+    for(int i = 0; i < n_comments; i++) {
+        sprintf(poster, "poster%03d", i);
+        error = create_comment(main_id, poster, (char *)"10.1.1.4", 10, (char *)"test1test1", COMMENT_TYPE_GOOD, comment_id);
+        EXPECT_EQ(S_OK, error);
+    }
+
+    int len;
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, 0, (char *)"", READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 0; i < 10; i++) {
+        sprintf(poster, "poster%03d", i);
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main: (%d/%d) (%lld/%s)\n", i, 10, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main2)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    char poster[IDLEN + 1] = {};
+    int n_comments = 100;
+    for(int i = 0; i < n_comments; i++) {
+        sprintf(poster, "poster%03d", i);
+        error = create_comment(main_id, poster, (char *)"10.1.1.4", 10, (char *)"test1test1", COMMENT_TYPE_GOOD, comment_id);
+        EXPECT_EQ(S_OK, error);
+    }
+
+    int len;
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, 0, (char *)"", READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 0; i < 10; i++) {
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    error = read_comments_by_main(main_id, comments[9].create_milli_timestamp, comments[9].poster, READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments + 10, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 10; i < 20; i++) {
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main3)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    int n_comments = 100;
+    for(int i = 0; i < n_comments; i++) {
+        error = create_comment(main_id, (char *)"poster", (char *)"10.1.1.4", 10, (char *)"test1test1", COMMENT_TYPE_GOOD, comment_id);
+        usleep(1000);
+        EXPECT_EQ(S_OK, error);
+    }
+
+    int len;
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, 0, (char *)"", READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    time64_t first_create_milli_timestamp = comments[0].create_milli_timestamp;
+    for(int i = 0; i < 10; i++) {
+        EXPECT_LE(first_create_milli_timestamp + i, comments[i].create_milli_timestamp);
+        EXPECT_GT(first_create_milli_timestamp + i + 100, comments[i].create_milli_timestamp);
+    }
+
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main4)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    Comment comment = {};
+    init_comment_buf(&comment);
+    // comment
+    memcpy(comment.main_id, main_id, sizeof(UUID));
+    comment.status = LIVE_STATUS_ALIVE;
+    strcpy(comment.status_updater, "poster000");
+    strcpy(comment.status_update_ip, "10.1.1.4");
+
+    time64_t create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+
+    comment.comment_type = COMMENT_TYPE_GOOD;
+    comment.karma = KARMA_BY_COMMENT_TYPE[COMMENT_TYPE_GOOD];
+
+    strcpy(comment.poster, "poster000");
+    strcpy(comment.ip, "10.1.1.4");
+    comment.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment.updater, "poster000");
+    strcpy(comment.update_ip, "10.1.1.4");
+    comment.update_milli_timestamp = create_milli_timestamp;
+
+    strcpy(comment.buf, "test1test1");
+    comment.len = 10;
+
+    bson_t *comment_id_bson = NULL;
+    bson_t *comment_bson = NULL;
+
+    int n_comments = 100;
+    for(int i = 0; i < 15; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 15; i < n_comments; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + i;
+        comment.update_milli_timestamp = create_milli_timestamp + i;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    // get comments
+    int len;
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, 0, (char *)"", READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    char poster[20] = {};
+    for(int i = 0; i < 10; i++) {
+        EXPECT_EQ(create_milli_timestamp, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // free
+    destroy_comment(&comment);
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main5_GT)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    Comment comment = {};
+    init_comment_buf(&comment);
+    // comment
+    memcpy(comment.main_id, main_id, sizeof(UUID));
+    comment.status = LIVE_STATUS_ALIVE;
+    strcpy(comment.status_updater, "poster000");
+    strcpy(comment.status_update_ip, "10.1.1.4");
+
+    time64_t create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+
+    comment.comment_type = COMMENT_TYPE_GOOD;
+    comment.karma = KARMA_BY_COMMENT_TYPE[COMMENT_TYPE_GOOD];
+
+    strcpy(comment.poster, "poster000");
+    strcpy(comment.ip, "10.1.1.4");
+    comment.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment.updater, "poster000");
+    strcpy(comment.update_ip, "10.1.1.4");
+    comment.update_milli_timestamp = create_milli_timestamp;
+
+    strcpy(comment.buf, "test1test1");
+    comment.len = 10;
+
+    bson_t *comment_id_bson = NULL;
+    bson_t *comment_bson = NULL;
+
+    int n_comments = 100;
+    for(int i = 0; i < 15; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 15; i < n_comments; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + i;
+        comment.update_milli_timestamp = create_milli_timestamp + i;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+        
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    // get comments
+    int len;
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, 0, (char *)"", READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    char poster[20] = {};
+    for(int i = 0; i < 10; i++) {
+        EXPECT_EQ(create_milli_timestamp, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // get comments
+    error = read_comments_by_main(main_id, comments[9].create_milli_timestamp, comments[9].poster, READ_COMMENTS_OP_TYPE_GT, 10, MONGO_COMMENT, comments + 10, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 10; i < 15; i++) {
+        EXPECT_EQ(create_milli_timestamp, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    for(int i = 15; i < 20; i++) {
+        EXPECT_EQ(create_milli_timestamp + i, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // free
+    destroy_comment(&comment);
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main5_GTE)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    Comment comment = {};
+    init_comment_buf(&comment);
+    // comment
+    memcpy(comment.main_id, main_id, sizeof(UUID));
+    comment.status = LIVE_STATUS_ALIVE;
+    strcpy(comment.status_updater, "poster000");
+    strcpy(comment.status_update_ip, "10.1.1.4");
+
+    time64_t create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+
+    comment.comment_type = COMMENT_TYPE_GOOD;
+    comment.karma = KARMA_BY_COMMENT_TYPE[COMMENT_TYPE_GOOD];
+
+    strcpy(comment.poster, "poster000");
+    strcpy(comment.ip, "10.1.1.4");
+    comment.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment.updater, "poster000");
+    strcpy(comment.update_ip, "10.1.1.4");
+    comment.update_milli_timestamp = create_milli_timestamp;
+
+    strcpy(comment.buf, "test1test1");
+    comment.len = 10;
+
+    bson_t *comment_id_bson = NULL;
+    bson_t *comment_bson = NULL;
+
+    int n_comments = 100;
+    for(int i = 0; i < 15; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 15; i < n_comments; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + i;
+        comment.update_milli_timestamp = create_milli_timestamp + i;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+        
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    // get comments
+    int len;
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, 0, (char *)"", READ_COMMENTS_OP_TYPE_GTE, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    char poster[20] = {};
+    for(int i = 0; i < 10; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_GTE: after 1st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 10, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // get comments
+    error = read_comments_by_main(main_id, comments[9].create_milli_timestamp, comments[9].poster, READ_COMMENTS_OP_TYPE_GTE, 10, MONGO_COMMENT, comments + 10, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 10; i < 16; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_GTE: after 2nd read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 16, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i - 1);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    for(int i = 16; i < 20; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_GTE: after 2nd read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 20, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + i - 1, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", i - 1);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // free
+    destroy_comment(&comment);
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main5_LT)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    Comment comment = {};
+    init_comment_buf(&comment);
+    // comment
+    memcpy(comment.main_id, main_id, sizeof(UUID));
+    comment.status = LIVE_STATUS_ALIVE;
+    strcpy(comment.status_updater, "poster000");
+    strcpy(comment.status_update_ip, "10.1.1.4");
+
+    time64_t create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+
+    comment.comment_type = COMMENT_TYPE_GOOD;
+    comment.karma = KARMA_BY_COMMENT_TYPE[COMMENT_TYPE_GOOD];
+
+    strcpy(comment.poster, "poster000");
+    strcpy(comment.ip, "10.1.1.4");
+    comment.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment.updater, "poster000");
+    strcpy(comment.update_ip, "10.1.1.4");
+    comment.update_milli_timestamp = create_milli_timestamp;
+
+    strcpy(comment.buf, "test1test1");
+    comment.len = 10;
+
+    bson_t *comment_id_bson = NULL;
+    bson_t *comment_bson = NULL;
+
+    int n_comments = 100;
+    for(int i = 0; i < 15; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 15; i < 85; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + i;
+        comment.update_milli_timestamp = create_milli_timestamp + i;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+        
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 85; i < 100; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + 85;
+        comment.update_milli_timestamp = create_milli_timestamp + 85;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+        
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    // get comments
+    int len;
+    time64_t future_milli_timestamp = 0;
+    error = get_milli_timestamp(&future_milli_timestamp);
+    future_milli_timestamp += 10000;
+
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, future_milli_timestamp, (char *)"", READ_COMMENTS_OP_TYPE_LT, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    char poster[20] = {};
+    for(int i = 0; i < 10; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_LT: after 1st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 10, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + 85, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", 90 + i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // get comments
+    error = read_comments_by_main(main_id, comments[0].create_milli_timestamp, comments[0].poster, READ_COMMENTS_OP_TYPE_LT, 10, MONGO_COMMENT, comments + 10, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 10; i < 15; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_LT: after 2st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 15, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + 70 + i, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", 70 + i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    for(int i = 15; i < 20; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_LT: after 2st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 20, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + 85, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", 70 + i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // free
+    destroy_comment(&comment);
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+TEST(pttdb_comment, read_comments_by_main5_LTE)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT);
+
+    Err error = S_OK;
+    UUID main_id = {};
+    UUID comment_id = {};
+    gen_uuid(main_id);
+
+    Comment comment = {};
+    init_comment_buf(&comment);
+    // comment
+    memcpy(comment.main_id, main_id, sizeof(UUID));
+    comment.status = LIVE_STATUS_ALIVE;
+    strcpy(comment.status_updater, "poster000");
+    strcpy(comment.status_update_ip, "10.1.1.4");
+
+    time64_t create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+
+    comment.comment_type = COMMENT_TYPE_GOOD;
+    comment.karma = KARMA_BY_COMMENT_TYPE[COMMENT_TYPE_GOOD];
+
+    strcpy(comment.poster, "poster000");
+    strcpy(comment.ip, "10.1.1.4");
+    comment.create_milli_timestamp = create_milli_timestamp;
+    strcpy(comment.updater, "poster000");
+    strcpy(comment.update_ip, "10.1.1.4");
+    comment.update_milli_timestamp = create_milli_timestamp;
+
+    strcpy(comment.buf, "test1test1");
+    comment.len = 10;
+
+    bson_t *comment_id_bson = NULL;
+    bson_t *comment_bson = NULL;
+
+    int n_comments = 100;
+    for(int i = 0; i < 15; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 15; i < 85; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + i;
+        comment.update_milli_timestamp = create_milli_timestamp + i;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+        
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    for(int i = 85; i < 100; i++) {
+        gen_uuid(comment_id);
+        memcpy(comment.the_id, comment_id, sizeof(UUID));
+        sprintf(comment.poster, "poster%03d", i);
+
+        comment.create_milli_timestamp = create_milli_timestamp + 85;
+        comment.update_milli_timestamp = create_milli_timestamp + 85;
+
+        error = _serialize_comment_bson(&comment, &comment_bson);
+        error = _serialize_uuid_bson(comment_id, &comment_id_bson);
+        
+        error = db_update_one(MONGO_COMMENT, comment_id_bson, comment_bson, true);
+
+        bson_safe_destroy(&comment_bson);
+        bson_safe_destroy(&comment_id_bson);
+
+        EXPECT_EQ(S_OK, error);
+    }
+
+    // get comments
+    int len;
+    time64_t future_milli_timestamp = 0;
+    error = get_milli_timestamp(&future_milli_timestamp);
+    future_milli_timestamp += 10000;
+
+    Comment comments[100] = {};
+    for(int i = 0; i < 100; i++) {
+        init_comment_buf(&comments[i]);
+    }
+    error = read_comments_by_main(main_id, future_milli_timestamp, (char *)"", READ_COMMENTS_OP_TYPE_LTE, 10, MONGO_COMMENT, comments, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    char poster[20] = {};
+    for(int i = 0; i < 10; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_LTE: after 1st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 10, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + 85, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", 90 + i);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // get comments
+    error = read_comments_by_main(main_id, comments[0].create_milli_timestamp, comments[0].poster, READ_COMMENTS_OP_TYPE_LTE, 10, MONGO_COMMENT, comments + 10, &n_comments, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_comments);
+    EXPECT_EQ(100, len);
+    for(int i = 10; i < 14; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_LTE: after 2st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 14, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + 70 + i + 1, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", 70 + i + 1);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    for(int i = 14; i < 20; i++) {
+        fprintf(stderr, "test_pttdb_comment.read_comments_by_main5_LTE: after 2st read-comments-by-main: (%d/%d) (%lld/%s)\n", i, 20, comments[i].create_milli_timestamp, comments[i].poster);
+        EXPECT_EQ(create_milli_timestamp + 85, comments[i].create_milli_timestamp);
+        sprintf(poster, "poster%03d", 70 + i + 1);
+        EXPECT_STREQ(poster, comments[i].poster);
+    }
+
+    // free
+    destroy_comment(&comment);
+    for(int i = 0; i < 100; i++) {
+        destroy_comment(&comments[i]);
+    }
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_pttdb_comment.err", O_WRONLY | O_CREAT | O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",
+        "test",
+    };
+
+    err = init_mongo_global();
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+
+    if (FD) {
+        close(FD);
+        FD = 0;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_pttdb_comment_reply.cc
+++ b/tests/test_mbbsd/test_pttdb_comment_reply.cc
@@ -1,0 +1,252 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "pttdb.h"
+#include "pttdb_internal.h"
+#include "util_db_internal.h"
+
+TEST(pttdb_comment_reply, create_comment_reply) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT_REPLY);
+
+    UUID main_id;
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char content[] = "temp_content\r\n";
+    int len = strlen(content);
+    int n_line = 1;
+
+    UUID comment_id;
+    UUID comment_reply_id;
+    UUID tmp_comment_reply_id;
+
+    gen_uuid(main_id);
+    gen_uuid(comment_reply_id);
+
+    Err error_code = create_comment_reply(main_id, comment_id, poster, ip, len, content, comment_reply_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    CommentReply comment_reply = {};
+    init_comment_reply_buf(&comment_reply);
+
+    memcpy(tmp_comment_reply_id, comment_reply_id, UUIDLEN);
+
+    error_code = read_comment_reply(comment_reply_id, &comment_reply);
+    EXPECT_EQ(S_OK, error_code);
+
+    EXPECT_EQ(0, strncmp((char *)tmp_comment_reply_id, (char *)comment_reply.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)comment_id, (char *)comment_reply.comment_id, UUIDLEN));
+
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)comment_reply.main_id, UUIDLEN));
+    EXPECT_EQ(LIVE_STATUS_ALIVE, comment_reply.status);
+
+    EXPECT_STREQ(poster, comment_reply.status_updater);
+    EXPECT_STREQ(ip, comment_reply.status_update_ip);
+
+    EXPECT_STREQ(poster, comment_reply.poster);
+    EXPECT_STREQ(ip, comment_reply.ip);
+
+    EXPECT_STREQ(poster, comment_reply.updater);
+    EXPECT_STREQ(ip, comment_reply.update_ip);
+
+    EXPECT_EQ(comment_reply.create_milli_timestamp, comment_reply.update_milli_timestamp);
+
+    EXPECT_EQ(len, comment_reply.len);
+    EXPECT_STREQ(content, comment_reply.buf);
+    EXPECT_EQ(n_line, comment_reply.n_line);
+
+    destroy_comment_reply(&comment_reply);
+}
+
+TEST(pttdb_comment_reply, delete_comment_reply) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT_REPLY);
+
+    UUID main_id;
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char content[] = "temp_content";
+    int len = strlen(content);
+
+    UUID comment_reply_id;
+    UUID comment_id;    
+
+    gen_uuid(main_id);
+    gen_uuid(comment_id);
+
+    Err error = create_comment_reply(main_id, comment_id, poster, ip, len, content, comment_reply_id);
+    EXPECT_EQ(S_OK, error);
+
+    char del_updater[IDLEN + 1] = "del_updater";
+    char status_update_ip[IPV4LEN + 1] = "10.1.1.4";
+    error = delete_comment_reply(comment_reply_id, del_updater, status_update_ip);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "status", BCON_BOOL(true),
+        "status_updater", BCON_BOOL(true),
+        "status_update_ip", BCON_BOOL(true)
+        );
+
+    bson_t *query = BCON_NEW(
+        "the_id", BCON_BINARY(comment_reply_id, UUIDLEN)
+    );
+    bson_t *result = NULL;
+
+    error = db_find_one(MONGO_COMMENT_REPLY, query, fields, &result);
+    EXPECT_EQ(S_OK, error);
+    int result_status;
+    char result_status_updater[MAX_BUF_SIZE];
+    char result_status_update_ip[MAX_BUF_SIZE];
+    bson_get_value_int32(result, (char *)"status", &result_status);
+    bson_get_value_bin(result, (char *)"status_updater", MAX_BUF_SIZE, result_status_updater, &len);
+    bson_get_value_bin(result, (char *)"status_update_ip", MAX_BUF_SIZE, result_status_update_ip, &len);
+
+    EXPECT_EQ(LIVE_STATUS_DELETED, result_status);
+    EXPECT_STREQ(del_updater, result_status_updater);
+    EXPECT_STREQ(status_update_ip, result_status_update_ip);
+
+    bson_safe_destroy(&query);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&result);
+}
+
+TEST(pttdb_comment_reply, get_comment_reply_info_by_main) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_COMMENT_REPLY);
+    UUID main_id = {};
+    UUID comment_reply_id = {};
+    UUID comment_reply_id2 = {};
+    UUID comment_id = {};
+    UUID comment_id2 = {};
+
+    gen_uuid(main_id);
+    gen_uuid(comment_id);
+    gen_uuid(comment_id2);
+
+    Err error = S_OK;
+    error = create_comment_reply(main_id, comment_id, (char *)"poster1", (char *)"10.3.1.4", 24, (char *)"test1test1\r\ntest3test3\r\n", comment_reply_id);
+    EXPECT_EQ(S_OK, error);
+    error = create_comment_reply(main_id, comment_id2, (char *)"poster1", (char *)"10.3.1.4", 12, (char *)"test2test2\r\n", comment_reply_id2);
+    EXPECT_EQ(S_OK, error);
+
+    int n_total_comments = 0;
+    int total_len = 0;
+    int n_line = 0;
+    error = get_comment_reply_info_by_main(main_id, &n_total_comments, &n_line, &total_len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(2, n_total_comments);
+    EXPECT_EQ(3, n_line);
+    EXPECT_EQ(36, total_len);
+}
+
+TEST(pttdb_comment_reply, serialize_comment_reply_bson) {
+    CommentReply comment_reply = {};
+    CommentReply comment_reply2 = {};
+
+    init_comment_reply_buf(&comment_reply);
+    init_comment_reply_buf(&comment_reply2);
+
+    comment_reply.version = 2;
+    gen_uuid(comment_reply.the_id);
+    memcpy(comment_reply.comment_id, comment_reply.the_id, UUIDLEN);
+    gen_uuid(comment_reply.main_id);
+    comment_reply.status = LIVE_STATUS_ALIVE;
+
+    strcpy(comment_reply.status_updater, "updater1");
+    strcpy(comment_reply.status_update_ip, "10.3.1.4");
+
+    strcpy(comment_reply.poster, "poster1");
+    strcpy(comment_reply.ip, "10.3.1.5");
+    comment_reply.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(comment_reply.updater, "updater2");
+    strcpy(comment_reply.update_ip, "10.3.1.6");
+    comment_reply.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+
+    strcpy(comment_reply.buf, "test_buf\r\n");
+    comment_reply.len = strlen(comment_reply.buf);
+    comment_reply.n_line = 1;
+
+    bson_t *comment_reply_bson = NULL;
+
+    Err error = _serialize_comment_reply_bson(&comment_reply, &comment_reply_bson);
+    EXPECT_EQ(S_OK, error);
+
+    char *str = bson_as_canonical_extended_json(comment_reply_bson, NULL);
+    fprintf(stderr, "test_pttdb_comment_reply.serialize_comment_reply_bson: comment_reply_bson: %s\n", str);
+    bson_free(str);
+
+    error = _deserialize_comment_reply_bson(comment_reply_bson, &comment_reply2);
+
+    bson_safe_destroy(&comment_reply_bson);
+
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(comment_reply.version, comment_reply2.version);
+    EXPECT_EQ(0, strncmp((char *)comment_reply.the_id, (char *)comment_reply2.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)comment_reply.comment_id, (char *)comment_reply2.comment_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)comment_reply.main_id, (char *)comment_reply2.main_id, UUIDLEN));
+    EXPECT_EQ(comment_reply.status, comment_reply2.status);
+    EXPECT_STREQ(comment_reply.status_updater, comment_reply2.status_updater);
+    EXPECT_STREQ(comment_reply.status_update_ip, comment_reply2.status_update_ip);
+    EXPECT_STREQ(comment_reply.poster, comment_reply2.poster);
+    EXPECT_STREQ(comment_reply.ip, comment_reply2.ip);
+    EXPECT_EQ(comment_reply.create_milli_timestamp, comment_reply2.create_milli_timestamp);
+    EXPECT_STREQ(comment_reply.updater, comment_reply2.updater);
+    EXPECT_STREQ(comment_reply.update_ip, comment_reply2.update_ip);
+    EXPECT_EQ(comment_reply.update_milli_timestamp, comment_reply2.update_milli_timestamp);
+    EXPECT_EQ(comment_reply.len, comment_reply2.len);
+    EXPECT_EQ(comment_reply.n_line, comment_reply2.n_line);
+    EXPECT_STREQ(comment_reply.buf, comment_reply2.buf);
+
+    destroy_comment_reply(&comment_reply);
+    destroy_comment_reply(&comment_reply2);
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_pttdb_comment_reply.err", O_WRONLY | O_CREAT | O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",
+        "test",
+    };
+
+    err = init_mongo_global();
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+
+    if (FD) {
+        close(FD);
+        FD = 0;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_pttdb_content_block.cc
+++ b/tests/test_mbbsd/test_pttdb_content_block.cc
@@ -1,0 +1,864 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "pttdb.h"
+#include "pttdb_internal.h"
+#include "util_db_internal.h"
+
+TEST(pttdb, save_content_block) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    ContentBlock content_block = {};
+    ContentBlock content_block2 = {};
+
+    // init content-block
+    error = reset_content_block(&content_block, ref_id, content_id, 3);
+    EXPECT_EQ(S_OK, error);
+
+    char buf[] = "test_buf\r\ntest2";
+    int len_buf = strlen(buf);
+    associate_content_block(&content_block, buf, len_buf);
+    content_block.len_block = len_buf;
+    content_block.n_line = 1;
+
+    // init content-block2
+    error = init_content_block_buf_block(&content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    // save
+    error = save_content_block(&content_block, MONGO_MAIN_CONTENT);
+    EXPECT_EQ(S_OK, error);
+
+    error = read_content_block(content_id, 3, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    EXPECT_EQ(0, strncmp(content_block2.buf_block, buf, len_buf));
+    EXPECT_EQ(MAX_BUF_SIZE, content_block2.max_buf_len);
+    EXPECT_EQ(len_buf, content_block2.len_block);
+    EXPECT_EQ(1, content_block2.n_line);
+
+    dissociate_content_block(&content_block);
+    destroy_content_block(&content_block2);
+}
+
+TEST(pttdb, read_content_block_forgot_init) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    ContentBlock content_block = {};
+    ContentBlock content_block2 = {};
+
+    // init content-block
+    error = reset_content_block(&content_block, ref_id, content_id, 3);
+    EXPECT_EQ(S_OK, error);
+
+    char buf[] = "test_buf\r\ntest2";
+    int len_buf = strlen(buf);
+    associate_content_block(&content_block, buf, len_buf);
+    content_block.len_block = len_buf;
+    content_block.n_line = 1;
+
+    // init content-block2
+    // error = init_content_block_buf_block(&content_block2);
+    // EXPECT_EQ(S_OK, error);
+
+    // save
+    error = save_content_block(&content_block, MONGO_MAIN_CONTENT);
+    EXPECT_EQ(S_OK, error);
+
+    error = read_content_block(content_id, 3, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_ERR, error);
+
+    dissociate_content_block(&content_block);
+    //destroy_content_block(&content_block2);
+}
+
+TEST(pttdb, reset_content_block) {
+    Err error;
+    ContentBlock content_block = {};
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    error = reset_content_block(&content_block, ref_id, content_id, 3);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(NULL, content_block.buf_block);
+    EXPECT_EQ(0, content_block.max_buf_len);
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(3, content_block.block_id);
+
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(NULL, content_block.buf_block);
+    EXPECT_EQ(0, content_block.max_buf_len);
+}
+
+TEST(pttdb, init_content_block_with_buf_block) {
+    Err error;
+    ContentBlock content_block = {};
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    error = init_content_block_with_buf_block(&content_block, ref_id, content_id, 3);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_NE(NULL, (unsigned long)content_block.buf_block);
+    EXPECT_EQ(MAX_BUF_SIZE, content_block.max_buf_len);
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(3, content_block.block_id);
+
+    error = destroy_content_block(&content_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(NULL, content_block.buf_block);
+    EXPECT_EQ(0, content_block.max_buf_len);
+}
+
+TEST(pttdb, associate_content_block) {
+    Err error;
+    ContentBlock content_block = {};
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    error = reset_content_block(&content_block, ref_id, content_id, 3);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(NULL, content_block.buf_block);
+    EXPECT_EQ(0, content_block.max_buf_len);
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(3, content_block.block_id);
+
+    char buf[20];
+    error = associate_content_block(&content_block, buf, 20);
+    EXPECT_EQ(buf, content_block.buf_block);
+    EXPECT_EQ(20, content_block.max_buf_len);
+
+    error = dissociate_content_block(&content_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(NULL, content_block.buf_block);
+    EXPECT_EQ(0, content_block.max_buf_len);
+}
+
+TEST(pttdb, serialize_content_block_bson) {
+    ContentBlock content_block = {};
+    ContentBlock content_block2 = {};
+
+    init_content_block_buf_block(&content_block);
+    init_content_block_buf_block(&content_block2);
+
+    // initialize
+    gen_uuid(content_block.the_id);
+    gen_uuid(content_block.ref_id);
+    content_block.block_id = 53;
+    content_block.n_line = 1;
+    char str[] = "test123\r\n";
+    content_block.len_block = strlen(str);
+    memcpy(content_block.buf_block, str, strlen(str));
+
+    // init-op
+    bson_t *b = NULL;
+
+    // do-op
+    Err error = _serialize_content_block_bson(&content_block, &b);
+    EXPECT_EQ(S_OK, error);
+
+    error = _deserialize_content_block_bson(b, &content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    // post-op
+    bson_safe_destroy(&b);
+
+    // expect
+    EXPECT_EQ(0, strncmp((char *)content_block.the_id, (char *)content_block2.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_block.ref_id, (char *)content_block2.ref_id, UUIDLEN));
+    EXPECT_EQ(content_block.block_id, content_block2.block_id);
+    EXPECT_EQ(content_block.len_block, content_block2.len_block);
+    EXPECT_EQ(content_block.n_line, content_block2.n_line);
+    EXPECT_STREQ(content_block.buf_block, content_block2.buf_block);
+
+    destroy_content_block(&content_block);
+    destroy_content_block(&content_block2);
+}
+
+TEST(pttdb, dynamic_read_content_blocks)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    bson_t *b[10];
+    UUID content_id;
+    UUID ref_id;
+
+    gen_uuid(content_id);
+    gen_uuid(ref_id);
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW(
+                   "the_id", BCON_BINARY(content_id, UUIDLEN),
+                   "block_id", BCON_INT32(i),
+                   "ref_id", BCON_BINARY(ref_id, UUIDLEN),
+                   "len_block", BCON_INT32(5),
+                   "n_line", BCON_INT32(0),
+                   "buf_block", BCON_BINARY((unsigned char *)"test1", 5)
+               );
+        db_update_one(MONGO_MAIN_CONTENT, b[i], b[i], true);
+    }
+
+    // content-block initialize
+    ContentBlock content_blocks[10] = {};
+
+    int len;
+    int n_block;
+    char buf[51] = {};
+    Err error = dynamic_read_content_blocks(content_id, 10, 0, MONGO_MAIN_CONTENT, buf, 50, content_blocks, &n_block, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_block);
+    EXPECT_EQ(50, len);
+    for (int i = 0; i < 10; i++) {
+        EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_blocks[i].the_id, UUIDLEN));
+        EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_blocks[i].ref_id, UUIDLEN));
+        EXPECT_EQ(5, content_blocks[i].len_block);
+        EXPECT_EQ(0, content_blocks[i].n_line);
+        EXPECT_EQ(0, strncmp((char *)"test1", content_blocks[i].buf_block, 5));
+        EXPECT_EQ(i, content_blocks[i].block_id);
+    }
+
+    EXPECT_STREQ("test1test1test1test1test1test1test1test1test1test1", buf);
+
+    for (int i = 0; i < 10; i++) {
+        dissociate_content_block(&content_blocks[i]);
+        bson_safe_destroy(&b[i]);
+    }
+}
+
+TEST(pttdb, dynamic_read_content_blocks2)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    bson_t *b[10];
+    UUID content_id;
+    UUID ref_id;
+
+    gen_uuid(content_id);
+    gen_uuid(ref_id);
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW(
+                   "the_id", BCON_BINARY(content_id, UUIDLEN),
+                   "block_id", BCON_INT32(i),
+                   "ref_id", BCON_BINARY(ref_id, UUIDLEN),
+                   "len_block", BCON_INT32(5),
+                   "n_line", BCON_INT32(0),
+                   "buf_block", BCON_BINARY((unsigned char *)"test1", 5)
+               );
+        db_update_one(MONGO_MAIN_CONTENT, b[i], b[i], true);
+    }
+
+    // content-block initialize
+    ContentBlock content_blocks[10] = {};
+
+    int len;
+    int n_block;
+    char buf[41] = {};
+    Err error = dynamic_read_content_blocks(content_id, 10, 0, MONGO_MAIN_CONTENT, buf, 40, content_blocks, &n_block, &len);
+    EXPECT_EQ(S_ERR_BUFFER_LEN, error);
+    EXPECT_EQ(8, n_block);
+    EXPECT_EQ(40, len);
+    for (int i = 0; i < 8; i++) {
+        EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_blocks[i].the_id, UUIDLEN));
+        EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_blocks[i].ref_id, UUIDLEN));
+        EXPECT_EQ(5, content_blocks[i].len_block);
+        EXPECT_EQ(0, content_blocks[i].n_line);
+        EXPECT_EQ(0, strncmp((char *)"test1", content_blocks[i].buf_block, 5));
+        EXPECT_EQ(i, content_blocks[i].block_id);
+    }
+
+    EXPECT_STREQ("test1test1test1test1test1test1test1test1", buf);
+
+    for (int i = 0; i < 10; i++) {
+        dissociate_content_block(&content_blocks[i]);
+        bson_safe_destroy(&b[i]);
+    }
+}
+
+TEST(pttdb, read_content_blocks)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    bson_t *b[10];
+    UUID content_id;
+    UUID ref_id;
+
+    gen_uuid(content_id);
+    gen_uuid(ref_id);
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW(
+                   "the_id", BCON_BINARY(content_id, UUIDLEN),
+                   "block_id", BCON_INT32(i),
+                   "ref_id", BCON_BINARY(ref_id, UUIDLEN),
+                   "len_block", BCON_INT32(5),
+                   "n_line", BCON_INT32(0),
+                   "buf_block", BCON_BINARY((unsigned char *)"test1", 5)
+               );
+        db_update_one(MONGO_MAIN_CONTENT, b[i], b[i], true);
+    }
+
+    // content-block initialize
+    ContentBlock content_blocks[10] = {};
+    for (int i = 0; i < 10; i++) {
+        init_content_block_buf_block(&content_blocks[i]);
+    }
+
+    int len;
+    int n_block;
+    Err error = read_content_blocks(content_id, 10, 0, MONGO_MAIN_CONTENT, content_blocks, &n_block, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_block);
+    EXPECT_EQ(50, len);
+    for (int i = 0; i < 10; i++) {
+        EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_blocks[i].the_id, UUIDLEN));
+        EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_blocks[i].ref_id, UUIDLEN));
+        EXPECT_EQ(5, content_blocks[i].len_block);
+        EXPECT_EQ(0, content_blocks[i].n_line);
+        EXPECT_EQ(0, strncmp((char *)"test1", content_blocks[i].buf_block, 5));
+        EXPECT_EQ(i, content_blocks[i].block_id);
+    }
+
+    for (int i = 0; i < 10; i++) {
+        destroy_content_block(&content_blocks[i]);
+        bson_safe_destroy(&b[i]);
+    }
+}
+
+TEST(pttdb, read_content_blocks_get_db_results)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    bson_t *b[10];
+    UUID content_id;
+    UUID ref_id;
+
+    gen_uuid(content_id);
+    gen_uuid(ref_id);
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW(
+                   "the_id", BCON_BINARY(content_id, UUIDLEN),
+                   "block_id", BCON_INT32(i),
+                   "ref_id", BCON_BINARY(ref_id, UUIDLEN),
+                   "len_block", BCON_INT32(5),
+                   "n_line", BCON_INT32(0),
+                   "buf_block", BCON_BINARY((unsigned char *)"test1", 5)
+               );
+        db_update_one(MONGO_MAIN_CONTENT, b[i], b[i], true);
+    }
+
+    bson_t *b2[10] = {};
+    int n_block;
+    bson_t *key = BCON_NEW(
+            "the_id", BCON_BINARY(content_id, UUIDLEN)
+        );
+    Err error = _read_content_blocks_get_db_results(b2, key, 10, 0, MONGO_MAIN_CONTENT, &n_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, n_block);
+
+    error = _ensure_block_ids(b2, 0, 10);
+    EXPECT_EQ(S_OK, error);
+
+    bson_safe_destroy(&key);
+    for (int i = 0; i < 10; i++) {
+        bson_safe_destroy(&b[i]);
+        bson_safe_destroy(&b2[i]);
+    }
+}
+
+TEST(pttdb, form_b_array_block_ids)
+{
+    bson_t *b = bson_new();
+
+    Err error = _form_b_array_block_ids(5, 10, b);
+    EXPECT_EQ(S_OK, error);
+
+    char *str = bson_as_canonical_extended_json(b, NULL);
+    EXPECT_STREQ("{ \"$in\" : [ { \"$numberInt\" : \"5\" }, { \"$numberInt\" : \"6\" }, { \"$numberInt\" : \"7\" }, { \"$numberInt\" : \"8\" }, { \"$numberInt\" : \"9\" }, { \"$numberInt\" : \"10\" }, { \"$numberInt\" : \"11\" }, { \"$numberInt\" : \"12\" }, { \"$numberInt\" : \"13\" }, { \"$numberInt\" : \"14\" } ] }", str);
+    fprintf(stderr, "test_pttdb_content_block.form_b_array_block_ids: str: %s\n", str);
+    free(str);
+
+    bson_safe_destroy(&b);
+}
+
+TEST(pttdb, ensure_block_ids)
+{
+    bson_t *b[10];
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW("block_id", BCON_INT32(i));
+    }
+
+    Err error = _ensure_block_ids(b, 0, 10);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_block_ids(b, 1, 10);
+    EXPECT_EQ(S_ERR, error);
+
+    for (int i = 0; i < 10; i++) {
+        bson_safe_destroy(&b[i]);
+    }
+}
+
+TEST(pttdb, ensure_block_ids2)
+{
+    bson_t *b[10];
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW("block_id", BCON_INT32(i + 5));
+    }
+
+    Err error = _ensure_block_ids(b, 5, 10);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_block_ids(b, 1, 10);
+    EXPECT_EQ(S_ERR, error);
+
+    for (int i = 0; i < 10; i++) {
+        bson_safe_destroy(&b[i]);
+    }
+}
+
+TEST(pttdb, sort_by_block_id)
+{
+    bson_t *b[10];
+    for (int i = 0; i < 10; i++) {
+        b[i] = BCON_NEW("block_id", BCON_INT32(9 - i));
+    }
+    Err error = _sort_by_block_id(b, 10);
+    EXPECT_EQ(S_OK, error);
+
+    error = _ensure_block_ids(b, 0, 10);
+    EXPECT_EQ(S_OK, error);
+
+    for (int i = 0; i < 10; i++) {
+        bson_safe_destroy(&b[i]);
+    }
+}
+
+TEST(pttdb, split_contents_core)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    char buf[MAX_BUF_SIZE * 2] = {};
+    char *p_buf = buf;
+    for (int i = 0; i < 1000; i++) {
+        sprintf(p_buf, "test456789\r\n");
+        p_buf += 12;
+    }
+    int bytes = strlen(buf);
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    int n_block = 0;
+    init_content_block_with_buf_block(&content_block, ref_id, content_id, n_block);
+    n_block++;
+
+    int n_line = 0;
+    char line[MAX_BUF_SIZE];
+    int bytes_in_line = 0;
+    Err error = _split_contents_core(buf, bytes, ref_id, content_id, MONGO_MAIN_CONTENT, &n_line, &n_block, line, &bytes_in_line, &content_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(1000, n_line);
+    EXPECT_EQ(4, n_block);
+    EXPECT_EQ(0, bytes_in_line);
+    EXPECT_EQ(232, content_block.n_line);
+    EXPECT_STREQ(buf + 9216, content_block.buf_block);
+    EXPECT_EQ(2784, content_block.len_block);
+
+    destroy_content_block(&content_block);
+}
+
+TEST(pttdb, split_contents_core2)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    char buf[MAX_BUF_SIZE * 2] = {};
+    char *p_buf = buf;
+    for (int i = 0; i < 100; i++) {
+        sprintf(p_buf, "test456789test456789test456789test456789test456789test456789test456789test456789test456789test456789\r\n");
+        p_buf += 102;
+    }
+    int bytes = strlen(buf);
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    int n_block = 0;
+    init_content_block_with_buf_block(&content_block, ref_id, content_id, n_block);
+    n_block++;
+
+    int n_line = 0;
+    char line[MAX_BUF_SIZE];
+    int bytes_in_line = 0;
+    Err error = _split_contents_core(buf, bytes, ref_id, content_id, MONGO_MAIN_CONTENT, &n_line, &n_block, line, &bytes_in_line, &content_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(100, n_line);
+    EXPECT_EQ(2, n_block);
+    EXPECT_EQ(0, bytes_in_line);
+    EXPECT_EQ(20, content_block.n_line);
+    EXPECT_STREQ(buf + 8160, content_block.buf_block);
+    EXPECT_EQ(2040, content_block.len_block);
+
+    destroy_content_block(&content_block);
+}
+
+TEST(pttdb, split_contents_core3)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    char buf[MAX_BUF_SIZE * 4] = {};
+    char *p_buf = buf;
+    sprintf(p_buf, "test456789test456789test456789test456789test456789test456789test456789test456789test456789test456789\r\n");
+    p_buf += 102;
+
+    for (int i = 0; i < 200; i++) {
+        sprintf(p_buf, "test456789test456789test456789test456789test456789test456789test456789test456789test456789test456789");
+        p_buf += 100;
+    }
+    sprintf(p_buf, "\r\n");
+    int bytes = strlen(buf);
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    int n_block = 0;
+    init_content_block_with_buf_block(&content_block, ref_id, content_id, n_block);
+    n_block++;
+
+    int n_line = 0;
+    char line[MAX_BUF_SIZE];
+    int bytes_in_line = 0;
+    Err error = _split_contents_core(buf, bytes, ref_id, content_id, MONGO_MAIN_CONTENT, &n_line, &n_block, line, &bytes_in_line, &content_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(2, n_line);
+    EXPECT_EQ(4, n_block);
+
+    // the rest 3618-block in the current block.
+    EXPECT_EQ(0, bytes_in_line);
+    EXPECT_EQ(1, content_block.n_line);
+    EXPECT_STREQ(buf + 102 + 8192 * 2, content_block.buf_block);
+    EXPECT_EQ(3618, content_block.len_block);
+    EXPECT_EQ(3, content_block.block_id);
+
+    ContentBlock content_block2 = {};
+    init_content_block_buf_block(&content_block2);
+
+    // only the 1st line get into the block-0.
+    error = read_content_block(content_id, 0, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(102, content_block2.len_block);
+    EXPECT_EQ(0, strncmp(buf, content_block2.buf_block, 102));
+    EXPECT_EQ(1, content_block2.n_line);
+    error = reset_content_block_buf_block(&content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    // the 1st 8192-block in the block-1
+    error = read_content_block(content_id, 1, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(8192, content_block2.len_block);
+    EXPECT_EQ(0, strncmp(buf + 102, content_block2.buf_block, 8192));
+    EXPECT_EQ(0, content_block2.n_line);
+    error = reset_content_block_buf_block(&content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    // the 2nd 8192-block in the block-2
+    error = read_content_block(content_id, 2, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(8192, content_block2.len_block);
+    EXPECT_EQ(0, strncmp(buf + 102 + 8192, content_block2.buf_block, 8192));
+    EXPECT_EQ(0, content_block2.n_line);
+    error = reset_content_block_buf_block(&content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    destroy_content_block(&content_block2);
+    destroy_content_block(&content_block);
+}
+
+TEST(pttdb, split_contents_core4)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    char buf[MAX_BUF_SIZE * 4] = {};
+    char *p_buf = buf;
+    sprintf(p_buf, "test456789test456789test456789test456789test456789test456789test456789test456789test456789test456789\r\n");
+    p_buf += 102;
+
+    for (int i = 0; i < 200; i++) {
+        sprintf(p_buf, "test456789test456789test456789test456789test456789test456789test456789test456789test456789test456789");
+        p_buf += 100;
+    }
+    int bytes = strlen(buf);
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    int n_block = 0;
+    init_content_block_with_buf_block(&content_block, ref_id, content_id, n_block);
+    n_block++;
+
+    int n_line = 0;
+    char line[MAX_BUF_SIZE];
+    int bytes_in_line = 0;
+    Err error = _split_contents_core(buf, bytes, ref_id, content_id, MONGO_MAIN_CONTENT, &n_line, &n_block, line, &bytes_in_line, &content_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(1, n_line);
+    EXPECT_EQ(3, n_block);
+
+    // the rest 3618-block in the line.
+    EXPECT_EQ(3616, bytes_in_line);
+    EXPECT_STREQ(buf + 102 + 8192 * 2, line);
+
+    // the 2nd 8192-block in the content_block.
+    EXPECT_EQ(0, content_block.n_line);
+    EXPECT_EQ(8192, content_block.len_block);
+    EXPECT_EQ(2, content_block.block_id);
+    EXPECT_EQ(0, strncmp(buf + 102 + 8192, content_block.buf_block, content_block.len_block));
+
+    ContentBlock content_block2 = {};
+    init_content_block_buf_block(&content_block2);
+
+    // only the 1st line get into the block-0.
+    error = read_content_block(content_id, 0, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(102, content_block2.len_block);
+    EXPECT_EQ(0, strncmp(buf, content_block2.buf_block, 102));
+    EXPECT_EQ(1, content_block2.n_line);
+    error = reset_content_block_buf_block(&content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    // the 1st 8192-block in the block-1
+    error = read_content_block(content_id, 1, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(8192, content_block2.len_block);
+    EXPECT_EQ(0, strncmp(buf + 102, content_block2.buf_block, 8192));
+    EXPECT_EQ(0, content_block2.n_line);
+    error = reset_content_block_buf_block(&content_block2);
+    EXPECT_EQ(S_OK, error);
+
+    // the 2nd 8192-block not in the db yet.
+    error = read_content_block(content_id, 2, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_ERR_NOT_EXISTS, error);
+
+    destroy_content_block(&content_block2);
+    destroy_content_block(&content_block);
+}
+
+TEST(pttdb, split_contents_core_one_line)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    char line[] = "testtesttesttest\r\n";
+    int bytes_in_line = strlen(line);
+    int n_line = 100;
+    int n_block = 0;
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    init_content_block_with_buf_block(&content_block, ref_id, content_id, n_block);
+    n_block++;
+
+    Err error = _split_contents_core_one_line(line, bytes_in_line, ref_id, content_id, MONGO_MAIN_CONTENT, &content_block, &n_line, &n_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(1, n_block);
+    EXPECT_EQ(101, n_line);
+
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(0, content_block.block_id);
+    EXPECT_EQ(bytes_in_line, content_block.len_block);
+    EXPECT_STREQ(line, content_block.buf_block);
+    EXPECT_EQ(1, content_block.n_line);
+    EXPECT_EQ(MAX_BUF_SIZE, content_block.max_buf_len);
+
+    destroy_content_block(&content_block);
+}
+
+TEST(pttdb, split_contents_core_one_line2_reaching_max_line)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    char line[] = "testtesttesttest\r\n";
+    int bytes_in_line = strlen(line);
+    int n_line = MAX_BUF_LINES;
+    int n_block = 0;
+
+    UUID ref_id;
+    UUID content_id;
+    gen_uuid(ref_id);
+    gen_uuid(content_id);
+
+    init_content_block_with_buf_block(&content_block, ref_id, content_id, n_block);
+    n_block++;
+
+    char origin_line[MAX_BUF_SIZE] = {};
+    char *p_char = content_block.buf_block;
+    for (int i = 0; i < MAX_BUF_LINES; i++) {
+        sprintf(p_char, "test1\r\n");
+        p_char += strlen(p_char);
+    }
+    content_block.len_block = strlen(content_block.buf_block);
+    content_block.n_line = MAX_BUF_LINES;
+    strcpy(origin_line, content_block.buf_block);
+
+    Err error = _split_contents_core_one_line(line, bytes_in_line, ref_id, content_id, MONGO_MAIN_CONTENT, &content_block, &n_line, &n_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(2, n_block);
+    EXPECT_EQ(MAX_BUF_LINES + 1, n_line);
+
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(1, content_block.block_id);
+    EXPECT_EQ(bytes_in_line, content_block.len_block);
+    EXPECT_STREQ(line, content_block.buf_block);
+    EXPECT_EQ(1, content_block.n_line);
+    EXPECT_EQ(MAX_BUF_SIZE, content_block.max_buf_len);
+
+    ContentBlock content_block2 = {};
+    init_content_block_buf_block(&content_block2);
+
+    error = read_content_block(content_id, 0, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block2.ref_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)content_block2.the_id, UUIDLEN));
+    EXPECT_EQ(0, content_block2.block_id);
+    EXPECT_EQ(strlen(origin_line), content_block2.len_block);
+    EXPECT_STREQ(origin_line, content_block2.buf_block);
+
+    destroy_content_block(&content_block2);
+    destroy_content_block(&content_block);
+}
+
+TEST(pttdb, split_contents_deal_with_last_line_block)
+{
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    ContentBlock content_block = {};
+    UUID the_id;
+    UUID ref_id;
+    gen_uuid(the_id);
+    gen_uuid(ref_id);
+    init_content_block_with_buf_block(&content_block, ref_id, the_id, 0);
+    EXPECT_EQ(MAX_BUF_SIZE, content_block.max_buf_len);
+
+    int bytes_in_line = 10;
+    char line[] = "test1test1";
+    int n_line;
+    int n_block = 1;
+
+    Err error = _split_contents_deal_with_last_line_block(bytes_in_line, line, ref_id, the_id, MONGO_MAIN_CONTENT, &content_block, &n_line, &n_block);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(0, n_line);
+    EXPECT_EQ(1, n_block);
+    EXPECT_STREQ("test1test1", content_block.buf_block);
+    EXPECT_EQ(0, content_block.n_line);
+    EXPECT_EQ(10, content_block.len_block);
+    EXPECT_EQ(0, strncmp((char *)the_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, content_block.block_id);
+
+    ContentBlock content_block2 = {};
+    init_content_block_buf_block(&content_block2);
+    EXPECT_EQ(MAX_BUF_SIZE, content_block2.max_buf_len);
+
+    error = read_content_block(the_id, 0, MONGO_MAIN_CONTENT, &content_block2);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(0, strncmp((char *)content_block2.the_id, (char *)content_block.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_block2.ref_id, (char *)content_block.ref_id, UUIDLEN));
+    EXPECT_EQ(0, content_block2.block_id);
+    EXPECT_EQ(10, content_block2.len_block);
+    EXPECT_STREQ("test1test1", content_block2.buf_block);
+    EXPECT_EQ(0, content_block2.n_line);
+
+    destroy_content_block(&content_block2);
+    destroy_content_block(&content_block);
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_pttdb_content_block.err", O_WRONLY | O_CREAT | O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",      //MONGO_POST_DBNAME
+        "test",           //MONGO_TEST_DBNAME
+    };
+
+    err = init_mongo_global();
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+
+    if (FD) {
+        close(FD);
+        FD = 0;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_pttdb_main.cc
+++ b/tests/test_mbbsd/test_pttdb_main.cc
@@ -1,0 +1,1134 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "pttdb.h"
+#include "pttdb_internal.h"
+#include "util_db_internal.h"
+
+TEST(pttdb, create_main_from_fd_test1_read_main_content) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test1.txt", O_RDONLY);
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10000;
+    UUID main_id;
+    UUID content_id;
+
+    char tmp_main_id[UUIDLEN + 1] = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    // create-main-from-fd
+    Err error_code = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    close(fd);
+
+    strncpy((char *)tmp_main_id, (char *)main_id, UUIDLEN);
+    fprintf(stderr, "test_pttdb_main.create_main_from_fd: after create_main_from_fd: main_id: %s\n", tmp_main_id);
+
+    // read main-header
+    MainHeader main_header = {};
+    error_code = read_main_header(main_id, &main_header);
+    EXPECT_EQ(S_OK, error_code);
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)main_header.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)main_header.content_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)main_header.update_content_id, UUIDLEN));
+    EXPECT_EQ(aid, main_header.aid);
+    EXPECT_EQ(LIVE_STATUS_ALIVE, main_header.status);
+
+    EXPECT_STREQ(poster, main_header.status_updater);
+    EXPECT_STREQ(ip, main_header.status_update_ip);
+
+    EXPECT_STREQ(board, main_header.board);
+    EXPECT_STREQ(title, main_header.title);
+    EXPECT_STREQ(poster, main_header.poster);
+    EXPECT_STREQ(ip, main_header.ip);
+    EXPECT_STREQ(poster, main_header.updater);
+    EXPECT_STREQ(ip, main_header.update_ip);
+
+    EXPECT_STREQ(origin, main_header.origin);
+    EXPECT_STREQ(web_link, main_header.web_link);
+
+    EXPECT_EQ(0, main_header.reset_karma);
+
+    EXPECT_EQ(len, main_header.len_total);
+    EXPECT_EQ(2, main_header.n_total_block);
+    EXPECT_EQ(9, main_header.n_total_line);
+
+    fprintf(stderr, "test_pttdb_main.create_main_from_fd: to read content_block\n");
+
+    // read content-block
+    ContentBlock content_block0 = {};
+    ContentBlock content_block1 = {};
+
+    init_content_block_buf_block(&content_block0);
+    init_content_block_buf_block(&content_block1);
+
+    char *str_content = (char *)malloc(len);
+    fd = open("data_test/test1.txt", O_RDONLY);
+    read(fd, str_content, len);
+    close(fd);
+
+    error_code = read_content_block(main_header.content_id, 0, MONGO_MAIN_CONTENT, &content_block0);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = read_content_block(main_header.content_id, 1, MONGO_MAIN_CONTENT, &content_block1);
+    EXPECT_EQ(S_OK, error_code);
+
+    fprintf(stderr, "test_pttdb_main.create_main_from_fd: to do comparison\n");
+
+    EXPECT_EQ(len, content_block0.len_block + content_block1.len_block);
+    EXPECT_EQ(main_header.n_total_line, content_block0.n_line + content_block1.n_line);
+    EXPECT_EQ(0, strncmp((char *)content_block0.buf_block, str_content, content_block0.len_block));
+    EXPECT_EQ(0, strncmp((char *)content_block1.buf_block, str_content + content_block0.len_block, content_block1.len_block));
+
+    destroy_content_block(&content_block0);
+    destroy_content_block(&content_block1);
+    free(str_content);
+}
+
+
+TEST(pttdb, create_main_from_fd_test1) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test1.txt", O_RDONLY);
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10000;
+    UUID main_id;
+    UUID content_id;
+
+    char tmp_main_id[UUIDLEN + 1] = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    // create main from fd
+    Err error_code = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    strncpy((char *)tmp_main_id, (char *)main_id, UUIDLEN);
+    fprintf(stderr, "test_pttdb.create_main_from_fd: after create_main_from_fd: main_id: %s\n", tmp_main_id);
+
+    // read main-header
+    MainHeader main_header = {};
+
+    error_code = read_main_header(main_id, &main_header);
+    EXPECT_EQ(S_OK, error_code);
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)main_header.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)main_header.content_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)main_header.update_content_id, UUIDLEN));
+    EXPECT_EQ(aid, main_header.aid);
+    EXPECT_EQ(LIVE_STATUS_ALIVE, main_header.status);
+
+    EXPECT_STREQ(poster, main_header.status_updater);
+    EXPECT_STREQ(ip, main_header.status_update_ip);
+
+    EXPECT_STREQ(board, main_header.board);
+    EXPECT_STREQ(title, main_header.title);
+    EXPECT_STREQ(poster, main_header.poster);
+    EXPECT_STREQ(ip, main_header.ip);
+    EXPECT_STREQ(poster, main_header.updater);
+    EXPECT_STREQ(ip, main_header.update_ip);
+
+    EXPECT_STREQ(origin, main_header.origin);
+    EXPECT_STREQ(web_link, main_header.web_link);
+
+    EXPECT_EQ(0, main_header.reset_karma);
+
+    EXPECT_EQ(len, main_header.len_total);
+    EXPECT_EQ(2, main_header.n_total_block);
+    EXPECT_EQ(9, main_header.n_total_line);
+
+    close(fd);
+}
+
+TEST(pttdb, create_main_from_fd_test2_read_main_content) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test2.txt", O_RDONLY);
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10000;
+    UUID main_id;
+    UUID content_id;
+
+    char tmp_main_id[UUIDLEN + 1] = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    // create main from fd
+    Err error_code = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    strncpy((char *)tmp_main_id, (char *)main_id, UUIDLEN);
+    fprintf(stderr, "test_pttdb.create_main_from_fd: after create_main_from_fd: main_id: %s\n", tmp_main_id);
+
+    MainHeader main_header = {};
+
+    // read main-header
+    error_code = read_main_header(main_id, &main_header);
+    EXPECT_EQ(S_OK, error_code);
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)main_header.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header.update_content_id, UUIDLEN));
+    EXPECT_EQ(aid, main_header.aid);
+    EXPECT_EQ(LIVE_STATUS_ALIVE, main_header.status);
+
+    EXPECT_STREQ(poster, main_header.status_updater);
+    EXPECT_STREQ(ip, main_header.status_update_ip);
+
+    EXPECT_STREQ(board, main_header.board);
+    EXPECT_STREQ(title, main_header.title);
+    EXPECT_STREQ(poster, main_header.poster);
+    EXPECT_STREQ(ip, main_header.ip);
+    EXPECT_STREQ(poster, main_header.updater);
+    EXPECT_STREQ(ip, main_header.update_ip);
+
+    EXPECT_STREQ(origin, main_header.origin);
+    EXPECT_STREQ(web_link, main_header.web_link);
+
+    EXPECT_EQ(0, main_header.reset_karma);
+
+    EXPECT_EQ(len, main_header.len_total);
+    EXPECT_EQ(2, main_header.n_total_block);
+    EXPECT_EQ(0, main_header.n_total_line);
+
+    close(fd);
+
+    // read content block
+    ContentBlock content_block0 = {};
+    ContentBlock content_block1 = {};
+
+    init_content_block_buf_block(&content_block0);
+    init_content_block_buf_block(&content_block1);
+
+    char *str_content = (char *)malloc(len);
+    fd = open("data_test/test2.txt", O_RDONLY);
+    read(fd, str_content, len);
+    close(fd);
+
+    error_code = read_content_block(main_header.content_id, 0, MONGO_MAIN_CONTENT, &content_block0);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = read_content_block(main_header.content_id, 1, MONGO_MAIN_CONTENT, &content_block1);
+    EXPECT_EQ(S_OK, error_code);
+
+    EXPECT_EQ(len, content_block0.len_block + content_block1.len_block);
+    EXPECT_EQ(main_header.n_total_line, content_block0.n_line + content_block1.n_line);
+    EXPECT_EQ(0, strncmp((char *)content_block0.buf_block, str_content, content_block0.len_block));
+    EXPECT_EQ(0, strncmp((char *)content_block1.buf_block, str_content + content_block0.len_block, content_block1.len_block));
+
+    destroy_content_block(&content_block0);
+    destroy_content_block(&content_block1);
+
+    free(str_content);
+}
+
+TEST(pttdb, create_main_from_fd_test2) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test2.txt", O_RDONLY);
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10000;
+    UUID main_id;
+    UUID content_id;
+
+    char tmp_main_id[UUIDLEN + 1] = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    // create main from fd
+    Err error_code = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    strncpy((char *)tmp_main_id, (char *)main_id, UUIDLEN);
+    fprintf(stderr, "test_pttdb.create_main_from_fd: after create_main_from_fd: main_id: %s\n", tmp_main_id);
+
+    MainHeader main_header = {};
+
+    // read main-header
+    error_code = read_main_header(main_id, &main_header);
+    EXPECT_EQ(S_OK, error_code);
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)main_header.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header.update_content_id, UUIDLEN));
+    EXPECT_EQ(aid, main_header.aid);
+    EXPECT_EQ(LIVE_STATUS_ALIVE, main_header.status);
+
+    EXPECT_STREQ(poster, main_header.status_updater);
+    EXPECT_STREQ(ip, main_header.status_update_ip);
+
+    EXPECT_STREQ(board, main_header.board);
+    EXPECT_STREQ(title, main_header.title);
+    EXPECT_STREQ(poster, main_header.poster);
+    EXPECT_STREQ(ip, main_header.ip);
+    EXPECT_STREQ(poster, main_header.updater);
+    EXPECT_STREQ(ip, main_header.update_ip);
+
+    EXPECT_STREQ(origin, main_header.origin);
+    EXPECT_STREQ(web_link, main_header.web_link);
+
+    EXPECT_EQ(0, main_header.reset_karma);
+
+    EXPECT_EQ(len, main_header.len_total);
+    EXPECT_EQ(2, main_header.n_total_block);
+    EXPECT_EQ(0, main_header.n_total_line);
+
+    close(fd);
+}
+
+TEST(pttdb, create_main_from_fd_test1_full_read_main_content) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test1.txt", O_RDONLY);
+
+    time64_t start_timestamp;
+    time64_t end_timestamp;
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10020;
+    UUID main_id;
+    UUID content_id;
+
+    char tmp_main_id[UUIDLEN + 1] = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    Err error_code = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    strncpy((char *)tmp_main_id, (char *)main_id, UUIDLEN);
+    fprintf(stderr, "test_pttdb.create_main_from_fd: after create_main_from_fd: main_id: %s\n", tmp_main_id);
+
+    MainHeader main_header = {};
+
+    get_milli_timestamp(&start_timestamp);
+
+    error_code = read_main_header(main_id, &main_header);
+    EXPECT_EQ(S_OK, error_code);
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)main_header.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header.update_content_id, UUIDLEN));
+    EXPECT_EQ(aid, main_header.aid);
+    EXPECT_EQ(LIVE_STATUS_ALIVE, main_header.status);
+
+    EXPECT_STREQ(poster, main_header.status_updater);
+    EXPECT_STREQ(ip, main_header.status_update_ip);
+
+    EXPECT_STREQ(board, main_header.board);
+    EXPECT_STREQ(title, main_header.title);
+    EXPECT_STREQ(poster, main_header.poster);
+    EXPECT_STREQ(ip, main_header.ip);
+    EXPECT_STREQ(poster, main_header.updater);
+    EXPECT_STREQ(ip, main_header.update_ip);
+
+    EXPECT_STREQ(origin, main_header.origin);
+    EXPECT_STREQ(web_link, main_header.web_link);
+
+    EXPECT_EQ(0, main_header.reset_karma);
+
+    EXPECT_EQ(len, main_header.len_total);
+    EXPECT_EQ(2, main_header.n_total_block);
+    EXPECT_EQ(10, main_header.n_total_line);
+
+    close(fd);
+
+    ContentBlock content_block0 = {};
+    ContentBlock content_block1 = {};
+
+    init_content_block_buf_block(&content_block0);
+    init_content_block_buf_block(&content_block1);
+
+    char *str_content = (char *)malloc(len);
+    fd = open("data_test/test1.txt", O_RDONLY);
+    read(fd, str_content, len);
+    close(fd);
+
+    error_code = read_content_block(main_header.content_id, 0, MONGO_MAIN_CONTENT, &content_block0);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = read_content_block(main_header.content_id, 1, MONGO_MAIN_CONTENT, &content_block1);
+    EXPECT_EQ(S_OK, error_code);
+
+    EXPECT_EQ(len, content_block0.len_block + content_block1.len_block);
+    EXPECT_EQ(main_header.n_total_line, content_block0.n_line + content_block1.n_line);
+    EXPECT_EQ(0, strncmp((char *)content_block0.buf_block, str_content, content_block0.len_block));
+    EXPECT_EQ(0, strncmp((char *)content_block1.buf_block, str_content + content_block0.len_block, content_block1.len_block));
+
+    get_milli_timestamp(&end_timestamp);
+
+    fprintf(stderr, "pttdb.create_main_from_fd_test1_full_read_main_content: read: elapsed time: %lld\n", end_timestamp - start_timestamp);
+
+    destroy_content_block(&content_block0);
+    destroy_content_block(&content_block1);
+
+    free(str_content);
+}
+
+TEST(pttdb, create_main_from_fd_test1_full) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN_CONTENT);
+
+    int fd = open("data_test/test1.txt", O_RDONLY);
+
+    aidu_t aid = 12345;
+    char board[IDLEN + 1] = {};
+    char title[TTLEN + 1] = {};
+    char poster[IDLEN + 1] = {};
+    char ip[IPV4LEN + 1] = {};
+    char origin[MAX_ORIGIN_LEN + 1] = {};
+    char web_link[MAX_WEB_LINK_LEN + 1] = {};
+    int len = 10020;
+    UUID main_id;
+    UUID content_id;
+
+    char tmp_main_id[UUIDLEN + 1] = {};
+
+    strcpy(board, "test_board");
+    strcpy(title, "test_title");
+    strcpy(poster, "test_poster");
+    strcpy(ip, "test_ip");
+    strcpy(origin, "ptt.cc");
+    strcpy(web_link, "http://www.ptt.cc/bbs/alonglonglongboard/M.1234567890.ABCD.html");
+
+    // create main from fd
+    Err error_code = create_main_from_fd(aid, board, title, poster, ip, origin, web_link, len, fd, main_id, content_id);
+    EXPECT_EQ(S_OK, error_code);
+
+    strncpy((char *)tmp_main_id, (char *)main_id, UUIDLEN);
+    fprintf(stderr, "test_pttdb.create_main_from_fd: after create_main_from_fd: main_id: %s\n", tmp_main_id);
+
+    // read main header
+    MainHeader main_header = {};
+
+    error_code = read_main_header(main_id, &main_header);
+    EXPECT_EQ(S_OK, error_code);
+    EXPECT_EQ(0, strncmp((char *)main_id, (char *)main_header.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header.update_content_id, UUIDLEN));
+    EXPECT_EQ(aid, main_header.aid);
+    EXPECT_EQ(LIVE_STATUS_ALIVE, main_header.status);
+
+    EXPECT_STREQ(poster, main_header.status_updater);
+    EXPECT_STREQ(ip, main_header.status_update_ip);
+
+    EXPECT_STREQ(board, main_header.board);
+    EXPECT_STREQ(title, main_header.title);
+    EXPECT_STREQ(poster, main_header.poster);
+    EXPECT_STREQ(ip, main_header.ip);
+    EXPECT_STREQ(poster, main_header.updater);
+    EXPECT_STREQ(ip, main_header.update_ip);
+
+    EXPECT_STREQ(origin, main_header.origin);
+    EXPECT_STREQ(web_link, main_header.web_link);
+
+    EXPECT_EQ(0, main_header.reset_karma);
+
+    EXPECT_EQ(len, main_header.len_total);
+    EXPECT_EQ(2, main_header.n_total_block);
+    EXPECT_EQ(10, main_header.n_total_line);
+
+    close(fd);
+}
+
+TEST(pttdb, len_main) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    MainHeader main_header = {};
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    int len;
+    error = len_main(main_header.the_id, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(main_header.len_total, len);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, len_main_by_aid) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    MainHeader main_header = {};
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    int len;
+    error = len_main_by_aid(main_header.aid, &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(main_header.len_total, len);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, n_line_main) {
+    MainHeader main_header = {};
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    int n_line;
+    error = n_line_main(main_header.the_id, &n_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(main_header.n_total_line, n_line);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, n_line_main_by_aid) {
+    MainHeader main_header = {};
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    int n_line;
+    error = n_line_main_by_aid(main_header.aid, &n_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(main_header.n_total_line, n_line);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, read_main_header) {
+    MainHeader main_header = {};
+    MainHeader main_header2 = {};
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    char *str = bson_as_canonical_extended_json(main_bson, NULL);
+    fprintf(stderr, "test_pttdb.read_main_header: to db_update_one: main_bson: %s\n", str);
+    bson_free(str);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    error = read_main_header(main_header.the_id, &main_header2);
+    EXPECT_EQ(S_OK, error);
+
+    EXPECT_EQ(main_header.version, main_header2.version);
+    EXPECT_EQ(0, strncmp((char *)main_header.the_id, (char *)main_header2.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header2.content_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.update_content_id, (char *)main_header2.update_content_id, UUIDLEN));
+    EXPECT_EQ(main_header.aid, main_header2.aid);
+    EXPECT_EQ(main_header.status, main_header2.status);
+    EXPECT_STREQ(main_header.status_updater, main_header2.status_updater);
+    EXPECT_STREQ(main_header.status_update_ip, main_header2.status_update_ip);
+    EXPECT_STREQ(main_header.title, main_header2.title);
+    EXPECT_STREQ(main_header.poster, main_header2.poster);
+    EXPECT_STREQ(main_header.ip, main_header2.ip);
+    EXPECT_EQ(main_header.create_milli_timestamp, main_header2.create_milli_timestamp);
+    EXPECT_STREQ(main_header.updater, main_header2.updater);
+    EXPECT_STREQ(main_header.update_ip, main_header2.update_ip);
+    EXPECT_EQ(main_header.update_milli_timestamp, main_header2.update_milli_timestamp);
+    EXPECT_STREQ(main_header.origin, main_header2.origin);
+    EXPECT_STREQ(main_header.web_link, main_header2.web_link);
+    EXPECT_EQ(main_header.reset_karma, main_header2.reset_karma);
+    EXPECT_EQ(main_header.n_total_line, main_header2.n_total_line);
+    EXPECT_EQ(main_header.n_total_block, main_header2.n_total_block);
+    EXPECT_EQ(main_header.len_total, main_header2.len_total);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, read_main_header_by_aid) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    MainHeader main_header = {};
+    MainHeader main_header2 = {};
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    // db-update
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    // read
+    error = read_main_header_by_aid(main_header.aid, &main_header2);
+    EXPECT_EQ(S_OK, error);
+
+    EXPECT_EQ(main_header.version, main_header2.version);
+    EXPECT_EQ(0, strncmp((char *)main_header.the_id, (char *)main_header2.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header2.content_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.update_content_id, (char *)main_header2.update_content_id, UUIDLEN));
+    EXPECT_EQ(main_header.aid, main_header2.aid);
+    EXPECT_EQ(main_header.status, main_header2.status);
+    EXPECT_STREQ(main_header.status_updater, main_header2.status_updater);
+    EXPECT_STREQ(main_header.status_update_ip, main_header2.status_update_ip);
+    EXPECT_STREQ(main_header.title, main_header2.title);
+    EXPECT_STREQ(main_header.poster, main_header2.poster);
+    EXPECT_STREQ(main_header.ip, main_header2.ip);
+    EXPECT_EQ(main_header.create_milli_timestamp, main_header2.create_milli_timestamp);
+    EXPECT_STREQ(main_header.updater, main_header2.updater);
+    EXPECT_STREQ(main_header.update_ip, main_header2.update_ip);
+    EXPECT_EQ(main_header.update_milli_timestamp, main_header2.update_milli_timestamp);
+    EXPECT_STREQ(main_header.origin, main_header2.origin);
+    EXPECT_STREQ(main_header.web_link, main_header2.web_link);
+    EXPECT_EQ(main_header.reset_karma, main_header2.reset_karma);
+    EXPECT_EQ(main_header.n_total_line, main_header2.n_total_line);
+    EXPECT_EQ(main_header.n_total_block, main_header2.n_total_block);
+    EXPECT_EQ(main_header.len_total, main_header2.len_total);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, delete_main) {
+    MainHeader main_header = {};
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    // db-update
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    // delete
+    int len;
+    char del_updater[IDLEN + 1] = "del_updater";
+    char status_update_ip[IPV4LEN + 1] = "10.1.1.4";
+    error = delete_main(main_header.the_id, del_updater, status_update_ip);
+    EXPECT_EQ(S_OK, error);
+
+    // db-find
+    bson_t *query = BCON_NEW(
+        "the_id", BCON_BINARY(main_header.the_id, UUIDLEN)
+        );
+    bson_t *result = NULL;
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "status", BCON_BOOL(true),
+        "status_updater", BCON_BOOL(true),
+        "status_update_ip", BCON_BOOL(true)
+        );
+
+    error = db_find_one(MONGO_MAIN, query, fields, &result);
+
+    int result_status;
+    char result_status_updater[MAX_BUF_SIZE];
+    char result_status_update_ip[MAX_BUF_SIZE];
+    bson_get_value_int32(result, (char *)"status", &result_status);
+    bson_get_value_bin(result, (char *)"status_updater", MAX_BUF_SIZE, result_status_updater, &len);
+    bson_get_value_bin(result, (char *)"status_update_ip", MAX_BUF_SIZE, result_status_update_ip, &len);
+
+    EXPECT_EQ(LIVE_STATUS_DELETED, result_status);
+    EXPECT_STREQ(del_updater, result_status_updater);
+    EXPECT_STREQ(status_update_ip, result_status_update_ip);
+
+    bson_safe_destroy(&query);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&result);
+}
+
+TEST(pttdb, delete_main_by_aid) {
+    _DB_FORCE_DROP_COLLECTION(MONGO_MAIN);
+
+    MainHeader main_header = {};
+
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_update_one(MONGO_MAIN, main_bson, main_bson, true);
+    EXPECT_EQ(S_OK, error);
+
+    int len;
+    char del_updater[IDLEN + 1] = "del_updater";
+    char status_update_ip[IPV4LEN + 1] = "10.1.1.4";
+    error = delete_main_by_aid(main_header.aid, del_updater, status_update_ip);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *query = BCON_NEW(
+        "the_id", BCON_BINARY(main_header.the_id, UUIDLEN)
+        );
+    bson_t *result = NULL;
+
+    bson_t *fields = BCON_NEW(
+        "_id", BCON_BOOL(false),
+        "status", BCON_BOOL(true),
+        "status_updater", BCON_BOOL(true),
+        "status_update_ip", BCON_BOOL(true)
+        );
+
+    error = db_find_one(MONGO_MAIN, query, fields, &result);
+
+    int result_status;
+    char result_status_updater[MAX_BUF_SIZE];
+    char result_status_update_ip[MAX_BUF_SIZE];
+
+    bson_get_value_int32(result, (char *)"status", &result_status);
+    bson_get_value_bin(result, (char *)"status_updater", MAX_BUF_SIZE, result_status_updater, &len);
+    bson_get_value_bin(result, (char *)"status_update_ip", MAX_BUF_SIZE, result_status_update_ip, &len);
+
+    EXPECT_EQ(LIVE_STATUS_DELETED, result_status);
+    EXPECT_STREQ(del_updater, result_status_updater);
+    EXPECT_STREQ(status_update_ip, result_status_update_ip);
+
+    bson_safe_destroy(&query);
+    bson_safe_destroy(&result);
+    bson_safe_destroy(&fields);
+}
+
+TEST(pttdb, serialize_main_bson) {
+    MainHeader main_header = {};
+    MainHeader main_header2 = {};
+
+    main_header.version = 2;
+    gen_uuid(main_header.the_id);
+    gen_uuid(main_header.content_id);
+    gen_uuid(main_header.update_content_id);
+    main_header.aid = 12345;
+    main_header.status = LIVE_STATUS_ALIVE;
+    strcpy(main_header.status_updater, "updater1");
+    strcpy(main_header.status_update_ip, "10.1.1.1");
+    strcpy(main_header.board, "test_board");
+    strcpy(main_header.title, "test_title");
+    strcpy(main_header.poster, "poster1");
+    strcpy(main_header.ip, "10.1.1.2");
+    main_header.create_milli_timestamp = 1514764800000; //2018-01-01 08:00:00 CST
+    strcpy(main_header.updater, "updater2");
+    strcpy(main_header.update_ip, "10.1.1.3");
+    main_header.update_milli_timestamp = 1514764801000; //2018-01-01 08:00:01 CST
+    strcpy(main_header.origin, "ptt.cc");
+    strcpy(main_header.web_link, "https://www.ptt.cc/bbs/temp/M.1514764800.A.ABC.html");
+    main_header.reset_karma = -100;
+    main_header.n_total_line = 100;
+    main_header.n_total_block = 20;
+    main_header.len_total = 10000;
+
+    bson_t *main_bson = NULL;
+
+    Err error = _serialize_main_bson(&main_header, &main_bson);
+    EXPECT_EQ(S_OK, error);
+
+    char *str = bson_as_canonical_extended_json(main_bson, NULL);
+    fprintf(stderr, "main_bson: %s\n", str);
+    bson_free(str);
+
+    error = _deserialize_main_bson(main_bson, &main_header2);
+
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(main_header.version, main_header2.version);
+    EXPECT_EQ(0, strncmp((char *)main_header.the_id, (char *)main_header2.the_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.content_id, (char *)main_header2.content_id, UUIDLEN));
+    EXPECT_EQ(0, strncmp((char *)main_header.update_content_id, (char *)main_header2.update_content_id, UUIDLEN));
+    EXPECT_EQ(main_header.aid, main_header2.aid);
+    EXPECT_EQ(main_header.status, main_header2.status);
+    EXPECT_STREQ(main_header.status_updater, main_header2.status_updater);
+    EXPECT_STREQ(main_header.status_update_ip, main_header2.status_update_ip);
+    EXPECT_STREQ(main_header.title, main_header2.title);
+    EXPECT_STREQ(main_header.poster, main_header2.poster);
+    EXPECT_STREQ(main_header.ip, main_header2.ip);
+    EXPECT_EQ(main_header.create_milli_timestamp, main_header2.create_milli_timestamp);
+    EXPECT_STREQ(main_header.updater, main_header2.updater);
+    EXPECT_STREQ(main_header.update_ip, main_header2.update_ip);
+    EXPECT_EQ(main_header.update_milli_timestamp, main_header2.update_milli_timestamp);
+    EXPECT_STREQ(main_header.origin, main_header2.origin);
+    EXPECT_STREQ(main_header.web_link, main_header2.web_link);
+    EXPECT_EQ(main_header.reset_karma, main_header2.reset_karma);
+    EXPECT_EQ(main_header.n_total_line, main_header2.n_total_line);
+    EXPECT_EQ(main_header.n_total_block, main_header2.n_total_block);
+    EXPECT_EQ(main_header.len_total, main_header2.len_total);
+
+    bson_safe_destroy(&main_bson);
+}
+
+TEST(pttdb, serialize_update_main_bson) {
+    Err error_code = S_OK;
+    UUID content_id;
+    char updater[IDLEN + 1] = {};
+    char update_ip[IPV4LEN + 1] = {};
+    time64_t update_milli_timestamp;
+    int n_line;
+    int n_block;
+    int len;
+
+    UUID result_content_id;
+    char result_updater[IDLEN + 1] = {};
+    char result_update_ip[IPV4LEN + 1] = {};
+    time64_t result_update_milli_timestamp;
+    int result_n_line;
+    int result_n_block;
+    int result_len;
+
+    strcpy(updater, "updater1");
+    strcpy(update_ip, "10.1.1.5");
+    get_milli_timestamp(&update_milli_timestamp);
+    n_line = 103;
+    n_block = 32;
+    len = 2031;
+
+    bson_t *main_bson = NULL;
+    error_code = _serialize_update_main_bson(content_id, updater, update_ip, update_milli_timestamp, n_line, n_block, len, &main_bson);
+
+    int tmp = 0;
+
+    error_code = bson_get_value_bin(main_bson, (char *)"content_id", UUIDLEN, (char *)result_content_id, &tmp);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = bson_get_value_bin(main_bson, (char *)"updater", IDLEN, result_updater, &tmp);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = bson_get_value_bin(main_bson, (char *)"update_ip", IPV4LEN, result_update_ip, &tmp);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = bson_get_value_int64(main_bson, (char *)"update_milli_timestamp", (long *)&result_update_milli_timestamp);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = bson_get_value_int32(main_bson, (char *)"n_total_line", &result_n_line);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = bson_get_value_int32(main_bson, (char *)"n_total_block", &result_n_block);
+    EXPECT_EQ(S_OK, error_code);
+
+    error_code = bson_get_value_int32(main_bson, (char *)"len_total", &result_len);
+    EXPECT_EQ(S_OK, error_code);
+
+    EXPECT_EQ(0, strncmp((char *)content_id, (char *)result_content_id, UUIDLEN));
+    EXPECT_STREQ(updater, result_updater);
+    EXPECT_STREQ(update_ip, result_update_ip);
+    EXPECT_EQ(update_milli_timestamp, result_update_milli_timestamp);
+    EXPECT_EQ(n_line, result_n_line);
+    EXPECT_EQ(n_block, result_n_block);
+    EXPECT_EQ(len, result_len);
+
+    bson_safe_destroy(&main_bson);
+
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_pttdb_main.err", O_WRONLY | O_CREAT | O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",
+        "test",
+    };
+
+    err = init_mongo_global();
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+
+    FILE *f = fopen("data_test/test1.txt", "w");
+    for (int j = 0; j < 10; j++) {
+        for (int i = 0; i < 1000; i++) {
+            fprintf(f, "%c", 64 + (i % 26));
+        }
+        fprintf(f, "\r\n");
+    }
+    fclose(f);
+
+    f = fopen("data_test/test2.txt", "w");
+    for (int i = 0; i < 10000; i++) {
+        fprintf(f, "%c", 64 + (i % 26));
+    }
+    fclose(f);
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+
+    if (FD) {
+        close(FD);
+        FD = 0;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_pttdb_misc.cc
+++ b/tests/test_mbbsd/test_pttdb_misc.cc
@@ -1,0 +1,367 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "pttdb.h"
+#include "pttdb_internal.h"
+#include "util_db_internal.h"
+
+// 2018-01-01
+time64_t START_MILLI_TIMESTAMP = 1514764800000;
+
+// 2019-01-01
+time64_t END_MILLI_TIMESTAMP = 1546300800000;
+
+TEST(pttdb, get_milli_timestamp) {
+    time64_t t;
+    get_milli_timestamp(&t);
+
+    EXPECT_GE(t, START_MILLI_TIMESTAMP);
+    EXPECT_LT(t, END_MILLI_TIMESTAMP);
+}
+
+TEST(pttdb, gen_uuid) {
+    UUID uuid;
+    _UUID _uuid;
+    UUID uuid2;
+    _UUID _uuid2;
+    time64_t milli_timestamp;
+    time64_t milli_timestamp2;
+
+    gen_uuid(uuid);
+    uuid_to_milli_timestamp(uuid, &milli_timestamp);
+
+    EXPECT_GE(milli_timestamp, START_MILLI_TIMESTAMP);
+    EXPECT_LT(milli_timestamp, END_MILLI_TIMESTAMP);
+
+    b64_pton((char *)uuid, _uuid, _UUIDLEN);
+    EXPECT_EQ(0x60, _uuid[6] & 0xf0);
+
+    gen_uuid(uuid2);
+    uuid_to_milli_timestamp(uuid2, &milli_timestamp2);
+
+    EXPECT_NE(0, strncmp((char *)uuid, (char *)uuid2, UUIDLEN));
+    EXPECT_GE(milli_timestamp2, START_MILLI_TIMESTAMP);
+    EXPECT_LT(milli_timestamp2, END_MILLI_TIMESTAMP);
+    EXPECT_GE(milli_timestamp2, milli_timestamp);
+
+    b64_pton((char *)uuid2, _uuid2, _UUIDLEN);
+    EXPECT_EQ(0x60, _uuid2[6] & 0xf0);
+}
+
+TEST(pttdb, gen_uuid_with_db) {
+    UUID uuid;
+    _UUID _uuid;
+    UUID uuid2;
+    _UUID _uuid2;
+    time64_t milli_timestamp;
+    time64_t milli_timestamp2;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    gen_uuid_with_db(MONGO_TEST, uuid);
+    uuid_to_milli_timestamp(uuid, &milli_timestamp);
+
+    EXPECT_GE(milli_timestamp, START_MILLI_TIMESTAMP);
+    EXPECT_LT(milli_timestamp, END_MILLI_TIMESTAMP);
+
+    b64_pton((char *)uuid, _uuid, _UUIDLEN);
+    EXPECT_EQ(0x60, _uuid[6] & 0xf0);
+
+    gen_uuid_with_db(MONGO_TEST, uuid2);
+    uuid_to_milli_timestamp(uuid2, &milli_timestamp2);
+
+    EXPECT_GE(milli_timestamp2, START_MILLI_TIMESTAMP);
+    EXPECT_LT(milli_timestamp2, END_MILLI_TIMESTAMP);
+    EXPECT_GE(milli_timestamp2, milli_timestamp);
+
+    b64_pton((char *)uuid2, _uuid2, _UUIDLEN);
+    EXPECT_EQ(0x60, _uuid2[6] & 0xf0);
+
+    EXPECT_NE(0, strncmp((char *)uuid, (char *)uuid2, UUIDLEN));
+
+    EXPECT_NE(0, strncmp((char *)uuid, (char *)uuid2, UUIDLEN));
+}
+
+TEST(pttdb, serialize_uuid_bson) {
+    _UUID _uuid;
+    UUID uuid;
+    char *str;
+    char buf[MAX_BUF_SIZE];
+
+    bzero(_uuid, sizeof(_UUID));
+    b64_ntop(_uuid, _UUIDLEN, (char *)uuid, UUIDLEN);
+
+    bson_t *uuid_bson = NULL;
+
+    Err error = _serialize_uuid_bson(uuid, &uuid_bson);
+    str = bson_as_canonical_extended_json(uuid_bson, NULL);
+    strcpy(buf, str);
+    bson_free (str);
+
+    bson_safe_destroy(&uuid_bson);
+
+    fprintf(stderr, "buf: %s\n", buf);
+
+    EXPECT_EQ(S_OK, error);
+    EXPECT_STREQ("{ \"the_id\" : { \"$binary\" : { \"base64\": \"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQQ==\", \"subType\" : \"00\" } } }", buf);
+}
+
+TEST(pttdb, serialize_content_uuid_bson) {
+    _UUID _uuid;
+    UUID uuid;
+    char *str;
+    char buf[MAX_BUF_SIZE];
+
+    bzero(_uuid, sizeof(_UUID));
+    b64_ntop(_uuid, _UUIDLEN, (char *)uuid, UUIDLEN);
+
+    bson_t *uuid_bson;
+
+    Err error = _serialize_content_uuid_bson(uuid, 0, &uuid_bson);
+    str = bson_as_canonical_extended_json(uuid_bson, NULL);
+    strcpy(buf, str);
+
+    bson_free (str);
+
+    bson_safe_destroy(&uuid_bson);
+
+    EXPECT_EQ(S_OK, error);
+    EXPECT_STREQ("{ \"the_id\" : { \"$binary\" : { \"base64\": \"QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQQ==\", \"subType\" : \"00\" } }, \"block_id\" : { \"$numberInt\" : \"0\" } }", buf);
+}
+
+TEST(pttdb, uuid_to_milli_timestamp) {
+    UUID uuid;
+    time64_t milli_timestamp;
+
+    gen_uuid(uuid);
+    uuid_to_milli_timestamp(uuid, &milli_timestamp);
+
+    fprintf(stderr, "milli_timestamp: %lld\n", milli_timestamp);
+
+    EXPECT_GE(milli_timestamp, START_MILLI_TIMESTAMP);
+    EXPECT_LT(milli_timestamp, END_MILLI_TIMESTAMP);
+}
+
+TEST(pttdb, get_line_from_buf) {
+    int len_buf = 24;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 0;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "0123456789\r\nABCDEFGHIJ\r\n");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(12, bytes_in_new_line);
+    EXPECT_STREQ("0123456789\r\n", line);
+}
+
+TEST(pttdb, get_line_from_buf_with_offset_buf) {
+    int len_buf = 24;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 12;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "0123456789\r\nABCDEFGHIJ\r\n");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(12, bytes_in_new_line);
+    EXPECT_STREQ("ABCDEFGHIJ\r\n", line);
+}
+
+TEST(pttdb, get_line_from_buf_with_line_offset) {
+    int len_buf = 24;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 0;
+    int offset_line = 2;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "0123456789\r\nABCDEFGHIJ\r\n");
+    line[0] = '!';
+    line[1] = '@';
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(12, bytes_in_new_line);
+    EXPECT_STREQ("!@0123456789\r\n", line);
+}
+
+TEST(pttdb, get_line_from_buf_not_end) {
+    int len_buf = 10;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 0;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "0123456789");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_ERR, error);
+    EXPECT_EQ(10, bytes_in_new_line);
+    EXPECT_STREQ("0123456789", line);
+}
+
+TEST(pttdb, get_line_from_buf_offset_buf_not_end) {
+    int len_buf = 13;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 3;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "A\r\n0123456789");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_ERR, error);
+    EXPECT_EQ(10, bytes_in_new_line);
+    EXPECT_STREQ("0123456789", line);
+}
+
+TEST(pttdb, get_line_from_buf_r_only) {
+    int len_buf = 13;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 0;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "A\r0123456789");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_ERR, error);
+    EXPECT_EQ(13, bytes_in_new_line);
+    EXPECT_STREQ("A\r0123456789", line);
+}
+
+TEST(pttdb, get_line_from_buf_n_only) {
+    int len_buf = 13;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 0;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "A\n0123456789");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_ERR, error);
+    EXPECT_EQ(13, bytes_in_new_line);
+    EXPECT_STREQ("A\n0123456789", line);
+}
+
+TEST(pttdb, get_line_from_buf_line_with_max_buf_size) {
+    int len_buf = 22;
+    char buf[MAX_BUF_SIZE] = {};
+    char line[MAX_BUF_SIZE] = {};
+    int offset_buf = 0;
+    int offset_line = MAX_BUF_SIZE - 10;
+    int bytes_in_new_line = 0;
+
+    strcpy(buf, "01234567890123456789\r\n");
+
+    for(int i = 0; i < MAX_BUF_SIZE - 10; i++) line[i] = 'A';
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(10, bytes_in_new_line);
+    EXPECT_EQ(0, strncmp("0123456789", line + MAX_BUF_SIZE - 10, 10));
+}
+
+TEST(pttdb, get_line_from_buf_partial_line_break) {
+    int len_buf = 13;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 0;
+    int offset_line = 2;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "\n0123456789\r\n");
+    strcpy(line, "!\r");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(1, bytes_in_new_line);
+    EXPECT_STREQ("!\r\n", line);
+}
+
+TEST(pttdb, get_line_from_buf_end_of_buf) {
+    int len_buf = 12;
+    char buf[MAX_BUF_SIZE];
+    char line[MAX_BUF_SIZE];
+    int offset_buf = 12;
+    int offset_line = 0;
+    int bytes_in_new_line = 0;
+    bzero(line, sizeof(line));
+
+    strcpy(buf, "0123456789\r\n");
+
+    Err error = get_line_from_buf(buf, offset_buf, len_buf, line, offset_line, &bytes_in_new_line);
+    EXPECT_EQ(S_ERR, error);
+    EXPECT_EQ(0, bytes_in_new_line);
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_pttdb_misc.err", O_WRONLY | O_CREAT | O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",
+        "test",
+    };
+
+    err = init_mongo_global();
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if (err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+
+    if (FD) {
+        close(FD);
+        FD = 0;
+    }
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_mbbsd/test_util_db.cc
+++ b/tests/test_mbbsd/test_util_db.cc
@@ -1,0 +1,318 @@
+#include "gtest/gtest.h"
+#include "bbs.h"
+#include "ptterr.h"
+#include "util_db.h"
+#include "util_db_internal.h"
+
+TEST(util_db, db_set_if_not_exists) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *b = BCON_NEW("test", BCON_INT32(1));
+
+    error = db_set_if_not_exists(MONGO_TEST, b);
+    EXPECT_EQ(S_OK, error);
+
+    if(!error) {
+        error = db_set_if_not_exists(MONGO_TEST, b);
+        EXPECT_EQ(S_ERR_ALREADY_EXISTS, error);
+    }
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_safe_destroy(&b);
+
+}
+
+TEST(util_db, db_update_one) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *key = BCON_NEW("the_key", BCON_BINARY((const unsigned char *)"key0", 4));
+    bson_t *val = BCON_NEW("the_val", BCON_BINARY((const unsigned char *)"val0", 4));
+
+    error = db_update_one(MONGO_TEST, key, val, true);
+    EXPECT_EQ(S_OK, error);
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+}
+
+TEST(util_db, db_find_one) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *key = BCON_NEW("the_key", BCON_INT32(4));
+    bson_t *val = BCON_NEW("the_val", BCON_INT32(5));
+
+    error = db_update_one(MONGO_TEST, key, val, true);
+    EXPECT_EQ(S_OK, error);
+
+    // result
+    bson_t *result = NULL;
+
+    fprintf(stderr, "test_db_find_one: to db_find_one\n");
+    error = db_find_one(MONGO_TEST, key, NULL, &result);
+    EXPECT_EQ(S_OK, error);
+
+    int int_result;
+    error = bson_get_value_int32(result, (char *)"the_key", &int_result);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(4, int_result);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+    bson_safe_destroy(&result);
+}
+
+TEST(util_db, db_find_one2_with_fields) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *key = BCON_NEW("the_key", BCON_INT32(4));
+    bson_t *val = BCON_NEW("the_val", BCON_INT32(5));
+
+    error = db_update_one(MONGO_TEST, key, val, true);
+    EXPECT_EQ(S_OK, error);
+
+    int int_result;
+    bson_t *fields = BCON_NEW("the_val", BCON_BOOL(true));
+    bson_t *result = NULL;
+
+    error = db_find_one(MONGO_TEST, key, fields, &result);
+    EXPECT_EQ(S_OK, error);
+
+    if(!error) {
+        error = bson_get_value_int32(result, (char *)"the_key", &int_result);
+        EXPECT_EQ(S_ERR, error);
+    }
+
+    if(!error) {
+        error = bson_get_value_int32(result, (char *)"the_val", &int_result);
+        EXPECT_EQ(S_OK, error);
+        EXPECT_EQ(int_result, 5);
+    }
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+    bson_safe_destroy(&fields);
+    bson_safe_destroy(&result);
+}
+
+TEST(util_db, db_remove) {
+    Err error;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *key = BCON_NEW("the_key", BCON_INT32(4));
+    bson_t *val = BCON_NEW("the_val", BCON_INT32(5));
+
+    error = db_update_one(MONGO_TEST, key, val, true);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *result = NULL;
+
+    error = db_remove(MONGO_TEST, key);
+    EXPECT_EQ(S_OK, error);
+
+    error = db_find_one(MONGO_TEST, key, NULL, &result);
+    EXPECT_EQ(S_ERR_NOT_EXISTS, error);
+    EXPECT_EQ(NULL, result);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+    bson_safe_destroy(&result);
+}
+
+TEST(util_db, db_aggregate) {
+    Err error = S_OK;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *key = BCON_NEW("tmp", BCON_INT32(4));
+    bson_t *val = BCON_NEW(
+        "len", BCON_INT32(5),
+        "main_id", BCON_INT32(4)
+        );
+
+    error = db_update_one(MONGO_TEST, key, val, true);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *key2 = BCON_NEW("tmp", BCON_INT32(5));
+    bson_t *val2 = BCON_NEW(
+        "len", BCON_INT32(10),
+        "main_id", BCON_INT32(4)
+        );
+
+    error = db_update_one(MONGO_TEST, key2, val2, true);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *pipeline = BCON_NEW(
+        "pipeline", "[",
+            "{",
+                "$match",
+                "{",
+                    "main_id", BCON_INT32(4),
+                "}",
+            "}",
+            "{",
+                "$group",
+                "{",
+                    "_id", BCON_NULL,
+                    "count", "{",
+                        "$sum", BCON_INT32(1),
+                    "}",
+                    "len", "{",
+                        "$sum", "$len",
+                    "}",
+                "}",
+            "}",
+        "]"
+        );    
+
+    char *str = bson_as_canonical_extended_json(pipeline, NULL);
+    fprintf(stderr, "test_util_db.db_aggregate: pipeline: %s\n", str);
+    bson_free(str);
+
+    bson_t *result = NULL;
+
+    int n_result;
+    error = db_aggregate(MONGO_TEST, pipeline, 1, &result, &n_result);
+    EXPECT_EQ(S_OK, error);
+
+    EXPECT_EQ(1, n_result);
+
+    str = bson_as_canonical_extended_json(result, NULL);
+    fprintf(stderr, "test_util_db.db_aggregate: result: %s\n", str);
+    bson_free(str);
+
+    int count = 0;
+    int len = 0;
+
+    error = bson_get_value_int32(result, (char *)"count", &count);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(2, count);
+
+    error = bson_get_value_int32(result, (char *)"len", &len);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(15, len);
+
+    bson_safe_destroy(&pipeline);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+    bson_safe_destroy(&key2);
+    bson_safe_destroy(&val2);
+
+    bson_safe_destroy(&result);
+}
+
+TEST(util_db, db_count) {
+    Err error = S_OK;
+
+    _DB_FORCE_DROP_COLLECTION(MONGO_TEST);
+
+    bson_t *key = BCON_NEW("tmp", BCON_INT32(4));
+    bson_t *val = BCON_NEW(
+        "len", BCON_INT32(5),
+        "main_id", BCON_INT32(4)
+        );
+
+    error = db_update_one(MONGO_TEST, key, val, true);
+    EXPECT_EQ(S_OK, error);
+
+    bson_t *key2 = BCON_NEW("tmp", BCON_INT32(5));
+    bson_t *val2 = BCON_NEW(
+        "len", BCON_INT32(10),
+        "main_id", BCON_INT32(4)
+        );
+
+    error = db_update_one(MONGO_TEST, key2, val2, true);
+    EXPECT_EQ(S_OK, error);
+
+    int count;
+
+    bson_t *query_key = BCON_NEW(
+        "main_id", BCON_INT32(4)
+        );
+
+    error = db_count(MONGO_TEST, query_key, &count);
+    EXPECT_EQ(S_OK, error);
+
+    EXPECT_EQ(2, count);
+
+    bson_safe_destroy(&query_key);
+
+    bson_safe_destroy(&key);
+    bson_safe_destroy(&val);
+
+    bson_safe_destroy(&key2);
+    bson_safe_destroy(&val2);
+}
+
+TEST(util_db, bson_safe_destroy) {
+    bson_t *b = NULL;
+    Err error = bson_safe_destroy(&b);
+    EXPECT_EQ(S_OK, error);
+}
+
+TEST(util_db, bson_safe_destroy2) {
+    bson_t *b = bson_new();
+    Err error = bson_safe_destroy(&b);
+    EXPECT_EQ(S_OK, error);
+    EXPECT_EQ(NULL, b);
+}
+
+/**********
+ * MAIN
+ */
+int FD = 0;
+
+class MyEnvironment: public ::testing::Environment {
+public:
+    void SetUp();
+    void TearDown();
+};
+
+void MyEnvironment::SetUp() {
+    Err err = S_OK;
+
+    FD = open("log.test_util_db.err", O_WRONLY|O_CREAT|O_TRUNC, 0660);
+    dup2(FD, 2);
+
+    const char *db_name[] = {
+        "test_post",
+        "test",
+    };
+
+    err = init_mongo_global();
+    if(err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo global\n");
+        return;
+    }
+    err = init_mongo_collections(db_name);
+    if(err != S_OK) {
+        fprintf(stderr, "[ERROR] UNABLE TO init mongo collections\n");
+        return;
+    }
+}
+
+void MyEnvironment::TearDown() {
+    free_mongo_collections();
+    free_mongo_global();
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new MyEnvironment);
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
    Support for mongo-db and googletest
    including:

    1. add googletest as unit-test
    2. have util_db as fundamental lib for mongodb-ops
    3. have pttdb_main as fundamental ops for main-contents
    4. have pttdb_content_block as fundamental structure for dealing with large-content (main-content)
    5. have pttdb_comment as fundamental ops for comments.
    6. have pttdb_comment_reply as fundametal ops for comment-reply.
    7. have pttdb_misc to deal with common ops for pttdb
    8. have doc in docs/pttdb.md and docs/unittest.md and docs/mongodb.md