### PR TITLE
Specify that Python environment in some utilities are Python 2.x.

### DIFF
--- a/common/sys/big5_gen.py
+++ b/common/sys/big5_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Usage: ./big5_gen.py > big5.c
 
 import sys

--- a/daemon/angelbeats/angel_perf.py
+++ b/daemon/angelbeats/angel_perf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #-*- coding: big5 -*-
 
 import collections

--- a/daemon/banipd/banipd.py
+++ b/daemon/banipd/banipd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2012 Hung-Te Lin <piaip@csie.ntu.edu.tw>. All rights reserved.
 # Use of this source code is governed by a BSD license.
 

--- a/daemon/brcstored/brcstored.py
+++ b/daemon/brcstored/brcstored.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (c) 2012 Hung-Te Lin <piaip@csie.ntu.edu.tw>. All rights reserved.
 # Use of this source code is governed by a BSD license.
 

--- a/daemon/commentd/commentd.py
+++ b/daemon/commentd/commentd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import struct
 import collections

--- a/daemon/postd/postd.py
+++ b/daemon/postd/postd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import collections
 import json

--- a/upgrade/r4132_reglog2db.py
+++ b/upgrade/r4132_reglog2db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # parse register.log and create reglog.db
 #

--- a/util/pyutil/big5.py
+++ b/util/pyutil/big5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import big5_tbl
 

--- a/util/pyutil/big5_gen.py
+++ b/util/pyutil/big5_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Usage: ./big5_gen.py > big5_tbl.py
 
 import os
@@ -17,7 +17,7 @@ b2u = [line.strip().split(' ')
        if line.strip().startswith('0x')]
 b2u = dict((int(b, 0), int(u, 0)) for (b, u) in b2u)
 
-print """#!/usr/bin/env python
+print """#!/usr/bin/env python2
 
 """
 print "b2u_table = ("

--- a/util/pyutil/pttpost.py
+++ b/util/pyutil/pttpost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding=latin1
 
 # This file is using latin1 with some Big5 literals, to prevent parsing files

--- a/util/pyutil/pttstruct.py
+++ b/util/pyutil/pttstruct.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: Big5 -*-
 
 import collections


### PR DESCRIPTION
Although most development environment assume `python` command as Python 2.x environment.

However, in some platform, especially some distribution with rolling release,
default `python` command is specified with Python 3.x environment.
but python utilities here are mostly designed for Python 2.x environment

So we may not assume all `python` command as Python 2.x environment.
unless some modules are really compatible with both Python 2.x and Python 3.x.