### PR TITLE
big5: let python script both compatible with python2 and python3

### DIFF
--- a/common/sys/big5_gen.py
+++ b/common/sys/big5_gen.py
@@ -18,17 +18,17 @@ b2u = [line.strip().split(b' ')
        if line.strip().startswith(b'0x')]
 b2u = dict((int(b, 0), int(u, 0)) for (b, u) in b2u)
 
-print ("""#include <stdint.h>
+print("""#include <stdint.h>
 extern const uint16_t b2u_table[];
 extern const uint16_t u2b_table[];
 extern const uint8_t b2u_ambiguous_width[];
 """)
-print ("const uint16_t b2u_table[0x10000] = {")
+print("const uint16_t b2u_table[0x10000] = {")
 for i in range(0x10000):
-    print ( '0x%04x,' % (i if i not in b2u else b2u[i]), end=' ')
+    print( '0x%04x,' % (i if i not in b2u else b2u[i]), end=' ')
     if i % 10 == 9:
-        print ('')
-print ("};\n")
+        print('')
+print("};\n")
 
 # u2b
 sys.stderr.write('Generating U2B data...\n')
@@ -38,12 +38,12 @@ u2b = [line.strip().split()
        if line.strip().startswith(b'0x')]
 u2b = dict((int(u, 0), int(b, 0)) for (b, u) in u2b)
 
-print ("const uint16_t u2b_table[0x10000] = {")
+print("const uint16_t u2b_table[0x10000] = {")
 for i in range(0x10000):
-    print ( '0x%04x,' % (i if i not in u2b else u2b[i]), end=' ')
+    print( '0x%04x,' % (i if i not in u2b else u2b[i]), end=' ')
     if i % 10 == 9:
-        print ('')
-print ("};\n")
+        print('')
+print("};\n")
 
 # ambiguous cjk width
 sys.stderr.write('Generating AMBCJK data...\n')
@@ -54,13 +54,13 @@ for entry in ambcjk_data:
     a = int(a, 0)
     b = int(b, 0)
     ambcjk = ambcjk + list( range(a, b+1) )
-print ("const uint8_t b2u_ambiguous_width[0x10000] = {")
+print("const uint8_t b2u_ambiguous_width[0x10000] = {")
 for i in range(0, 0x10000):
     if i in b2u and b2u[i] in ambcjk:
-        print ("1,",end=' '),
+        print("1,",end=' '),
     else:
-        print ("0,",end=' '),
+        print("0,",end=' '),
     if i % 25 == 24:
-        print ('')
+        print('')
 
-print ("};\n")
+print("};\n")

--- a/common/sys/big5_gen.py
+++ b/common/sys/big5_gen.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Usage: ./big5_gen.py > big5.c
 
+from __future__ import print_function
 import sys
 import tarfile
 
@@ -12,37 +13,37 @@ AMBCJK_FILE = BIG5_DATA.extractfile('ambcjk.big5.txt')
 # b2u
 sys.stderr.write('Generating B2U data...\n')
 b2u = B2U_FILE.readlines()
-b2u = [line.strip().split(' ')
+b2u = [line.strip().split(b' ')
        for line in b2u
-       if line.strip().startswith('0x')]
+       if line.strip().startswith(b'0x')]
 b2u = dict((int(b, 0), int(u, 0)) for (b, u) in b2u)
 
-print """#include <stdint.h>
+print ("""#include <stdint.h>
 extern const uint16_t b2u_table[];
 extern const uint16_t u2b_table[];
 extern const uint8_t b2u_ambiguous_width[];
-"""
-print "const uint16_t b2u_table[0x10000] = {"
+""")
+print ("const uint16_t b2u_table[0x10000] = {")
 for i in range(0x10000):
-    print '0x%04x,' % (i if i not in b2u else b2u[i]),
+    print ( '0x%04x,' % (i if i not in b2u else b2u[i]), end=' ')
     if i % 10 == 9:
-        print ''
-print "};\n"
+        print ('')
+print ("};\n")
 
 # u2b
 sys.stderr.write('Generating U2B data...\n')
 u2b = U2B_FILE.readlines()
-u2b = [line.strip().split(' ')
+u2b = [line.strip().split()
        for line in u2b
-       if line.strip().startswith('0x')]
+       if line.strip().startswith(b'0x')]
 u2b = dict((int(u, 0), int(b, 0)) for (b, u) in u2b)
 
-print "const uint16_t u2b_table[0x10000] = {"
+print ("const uint16_t u2b_table[0x10000] = {")
 for i in range(0x10000):
-    print '0x%04x,' % (i if i not in u2b else u2b[i]),
+    print ( '0x%04x,' % (i if i not in u2b else u2b[i]), end=' ')
     if i % 10 == 9:
-        print ''
-print "};\n"
+        print ('')
+print ("};\n")
 
 # ambiguous cjk width
 sys.stderr.write('Generating AMBCJK data...\n')
@@ -52,14 +53,14 @@ for entry in ambcjk_data:
     (a, b) = entry.strip().split()
     a = int(a, 0)
     b = int(b, 0)
-    ambcjk = ambcjk + range(a, b+1)
-print "const uint8_t b2u_ambiguous_width[0x10000] = {"
+    ambcjk = ambcjk + list( range(a, b+1) )
+print ("const uint8_t b2u_ambiguous_width[0x10000] = {")
 for i in range(0, 0x10000):
     if i in b2u and b2u[i] in ambcjk:
-        print "1,",
+        print ("1,",end=' '),
     else:
-        print "0,",
+        print ("0,",end=' '),
     if i % 25 == 24:
-        print ''
+        print ('')
 
-print "};\n"
+print ("};\n")

--- a/util/pyutil/big5_gen.py
+++ b/util/pyutil/big5_gen.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Usage: ./big5_gen.py > big5_tbl.py
 
+from __future__ import print_function
 import os
 import tarfile
 
@@ -12,31 +13,31 @@ U2B_FILE = BIG5_DATA.extractfile('uao250-u2b.big5.txt')
 
 # b2u
 b2u = B2U_FILE.readlines()
-b2u = [line.strip().split(' ')
+b2u = [line.strip().split(b' ')
        for line in b2u
-       if line.strip().startswith('0x')]
+       if line.strip().startswith(b'0x')]
 b2u = dict((int(b, 0), int(u, 0)) for (b, u) in b2u)
 
-print """#!/usr/bin/env python
+print ("""#!/usr/bin/env python
 
-"""
-print "b2u_table = ("
+""")
+print ("b2u_table = (")
 for i in range(0x10000):
-    print '0x%04x,' % (i if i not in b2u else b2u[i]),
+    print ('0x%04x,' % (i if i not in b2u else b2u[i]), end=' ')
     if i % 10 == 9:
-        print ''
-print ")\n"
+        print ('')
+print (")\n")
 
 # u2b
 u2b = U2B_FILE.readlines()
-u2b = [line.strip().split(' ')
+u2b = [line.strip().split(b' ')
        for line in u2b
-       if line.strip().startswith('0x')]
+       if line.strip().startswith(b'0x')]
 u2b = dict((int(u, 0), int(b, 0)) for (b, u) in u2b)
 
-print "u2b_table = ("
+print ("u2b_table = (")
 for i in range(0x10000):
-    print '0x%04x,' % (i if i not in u2b else u2b[i]),
+    print ('0x%04x,' % (i if i not in u2b else u2b[i]), end=' ')
     if i % 10 == 9:
-        print ''
-print ")\n"
+        print ('')
+print (")\n")


### PR DESCRIPTION
1. `print()` : change usage form `print "string"` to `print ("string")`
2. `print()` : change usage for some string not end with `\n`, and add `from __future__ import print_function` to let it compatible with python2.
3. let byte-like format can also be striped.
4. let `range()` format be converted to `list()` format

ps. 
there's my way to test if generated `big5.c` is still same:
```
python2 big5_gen.py > big5.c
curl -L https://raw.githubusercontent.com/clamtestbbs/pttbbs/r2.pyfix/common/sys/big5_gen.py > big5_gen_test.py
python2 big5_gen_test.py > big5_test2.c
python3 big5_gen_test.py > big5_test3.c
git diff --no-index big5.c big5_test2.c
git diff --no-index big5.c big5_test3.c
```