### PR TITLE
gamble.c: let procedure in buy_ticket_ui() more reasonable.

### DIFF
--- a/mbbsd/gamble.c
+++ b/mbbsd/gamble.c
@@ -186,12 +186,13 @@ buy_ticket_ui(int money, const char *picture, int *item,
 	return;
     }
 
-    *item += num;
-    pay(money * num, "%s彩券[種類%d,張數%d]", title, type+1, num);
-
     // XXX magic numbers 5, 14...
     show_file(picture, 5, 14, SHOWFILE_ALLOW_ALL);
     pressanykey();
+
+    *item += num;
+    pay(money * num, "%s彩券[種類%d,張數%d]", title, type+1, num);
+
     usleep(100000); // sleep 0.1s
 }
 


### PR DESCRIPTION
origin procedure:
user confirm > user pay > show tips (paused here) > write in ticket log > back to main ticket ui

if user abort the BBS program accidentally or on purpose in "show tips"( show_file() function )
the log for user payment and the ticket log will not be synchronized.

so this correction may solve this problem.

corrected procedure:
user confirm > show tips (paused here) > user pay > write in ticket log > back to main ticket ui

Note: tips message in etc/buyticket may also be checked if it is reasonable.

Related Bug Report:
https://www.ptt.cc/bbs/PttBug/M.1527581946.A.CB2.html
https://www.ptt.cc/bbs/PttBug/M.1527682178.A.ADB.html