### PR TITLE
Drop outta time

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*	encoding=big5

--- a/UPDATING
+++ b/UPDATING
@@ -22,6 +22,12 @@ https://opensvn.csie.org/traccgi/pttbbs/changeset/2273
     make r4871_uflag
 
 -----------------------------------------------------------------------------
+2019-03-14: [shm]
+OUTTA_TIMER 已經被移除。現代作業系統 (至少 Linux 和 FreeBSD) 在各硬體平台上
+都有支援 vDSO 之類的機制，可以讓 gettimeofday 不用 syscall 進 kernel 就取得
+目前的時間。此機制就如同原先 OUTTA_TIMER 的設計，但免卻了我們自己跑 daemon
+做同步。
+
 r5939: [shm]
 為了減少昇級 BBS 時資料結構不相容的情形，SHM 裡的 "now" 現在變為一直都有
 （即使沒開 OUTTA_TIMER 選項）。如果您的 BBS 沒開 OUTTA_TIMER 請記得打開後

--- a/include/pttstruct.h
+++ b/include/pttstruct.h
@@ -587,7 +587,7 @@ typedef struct {
 	    int     dymaxactive;  /* 笆篈砞﹚程计     */
 	    int     toomanyusers; /* 禬筁计ぃ倒秈计 */
 	    int     noonlineuser; /* ㄏノぃ蔼獹陪ボ   */
-	    time4_t now;
+	    time4_t now __attribute__ ((deprecated));
 	    int     nWelcomes;
 	    int     shutdown;     /* shutdown flag */
 

--- a/mbbsd/stuff.c
+++ b/mbbsd/stuff.c
@@ -104,11 +104,7 @@ gettime(int line, time4_t dt, const char* head)
 // synchronize 'now'
 void syncnow(void)
 {
-#ifdef OUTTA_TIMER
-        now = SHM->GV2.e.now;
-#else
 	now = time(0);
-#endif
 }
 
 void

--- a/mbbsd/var.c
+++ b/mbbsd/var.c
@@ -456,11 +456,7 @@ char    reentrant_write_request = 0;
 #endif
 
 #ifdef PTTBBS_UTIL
-    #ifdef OUTTA_TIMER
-	#define COMMON_TIME (SHM->GV2.e.now)
-    #else
-	#define COMMON_TIME (time(0))
-    #endif
+    #define COMMON_TIME (time(0))
 #else
     #define COMMON_TIME (now)
 #endif

--- a/sample/pttbbs.conf
+++ b/sample/pttbbs.conf
@@ -158,11 +158,6 @@
    仍可有好的上站率 */
 //#define PRE_FORK 10
 
-/* 若定義, 則由 shmctl utmpsortd 將 time(NULL) 寫入 SHM->GV2.e.now,
-   則不須每個 mbbsd都自己透過 time(NULL) 取得時間, 導致大量的 system call.
-   須要加跑 shmctl timed 來提供時間                                        */
-//#define OUTTA_TIMER
-
 /* 若定義, 則開啟 Big5 轉 UTF-8 的功能 */
 #define CONVERT
 

--- a/util/shmctl.c
+++ b/util/shmctl.c
@@ -158,11 +158,7 @@ int utmpfix(int argc, char **argv)
 
     printf("starting scaning... %s \n", (fast ? "(fast mode)" : ""));
     nownum = SHM->UTMPnumber;
-#ifdef OUTTA_TIMER
-    now = SHM->GV2.e.now;
-#else
     now = time(NULL);
-#endif
     for( i = 0, nactive = 0 ; i < USHM_SIZE ; ++i )
 	if( SHM->uinfo[i].pid ){
 	    idle[nactive].index = i;
@@ -383,11 +379,7 @@ void utmpsort(int sortall)
 
 
     SHM->UTMPbusystate = 1;
-#ifdef OUTTA_TIMER
-    SHM->UTMPuptime = SHM->GV2.e.now;
-#else
     SHM->UTMPuptime = time(NULL);
-#endif
     ns = (SHM->currsorted ? 0 : 1);
 
     for (uentp = &SHM->uinfo[0], count = i = 0;
@@ -529,11 +521,7 @@ int utmpstatus(int argc, char **argv)
     char    upbuf[64], nowbuf[64];
     (void)argc;
     (void)argv;
-#ifdef OUTTA_TIMER
-    now = SHM->GV2.e.now;
-#else
     now = time(NULL);
-#endif
     CTIMEx(upbuf,  SHM->UTMPuptime);
     CTIMEx(nowbuf, now);
     printf("now:        %s\n", nowbuf);
@@ -755,26 +743,6 @@ int fixbrd(int argc, char **argv)
     return 0;
 }
 
-#ifdef OUTTA_TIMER
-int timed(int argc, char **argv)
-{
-    pid_t   pid;
-    (void)argc;
-    (void)argv;
-    if( (pid = fork()) < 0 )
-	perror("fork()");
-    if( pid != 0 )
-	return 0;
-#ifndef VALGRIND
-    setproctitle("shmctl timed");
-#endif
-    while( 1 ){
-	SHM->GV2.e.now = time(NULL);
-	sleep(1);
-    }
-}
-#endif
-
 #if 0
 void buildclass(int bid, int level)
 {
@@ -847,11 +815,7 @@ int nkwbd(int argc, char **argv)
 	    int     i;
 	    time_t  now, t;
 
-#ifdef OUTTA_TIMER
-	    now = SHM->GV2.e.now;
-#else
 	    now = time(NULL);
-#endif
 	    t = now - timeout;
 
 	    for( i = 0 ; i < USHM_SIZE ; ++i )
@@ -890,11 +854,6 @@ int SHMinit(int argc, char **argv)
     system("bin/uhash_loader");
 
     attach_SHM();
-
-#ifdef OUTTA_TIMER
-    puts("timed...");
-    timed(1, argv);
-#endif
 
     puts("loading bcache...");
     reload_bcache();
@@ -1205,9 +1164,6 @@ struct Cmd {
 } cmd[] = { 
     {dummy,      "\b\b\b\bStart daemon:", ""},
     {utmpsortd,  "utmpsortd",  "utmp sorting daemon"},
-#ifdef OUTTA_TIMER
-    {timed,      "timed",      "time daemon for OUTTA_TIMER"},
-#endif
 #ifdef NOKILLWATERBALL
     {nkwbd,      "nkwbd",      "NOKillWaterBall daemon"},
 #endif


### PR DESCRIPTION
In the early days, OUTTA_TIMER provided a syscall-less mechanism to get
the approximate current time. This was implemented with a time value
stored in shared memory, which is updated every second by a separate
daemon.

On modern Linux and FreeBSD systems, the kernel provides a fast syscall
gettimeofday implementation that does not actually do a system call into
the kernel. Named vDSO on Linux, this is done by the kernel dynamically
mapping shared memory and a small code segment for gettimeofday (and
some other syscalls). gettimeofday retrieves the current time value from
the shared memory segment. This value is directly updated by the kernel
on each timer tick. In a sense this is a system-wide OUTTA_TIMER.

Thus we can get rid of our own custom implementation.