### PR TITLE
vote.c: remove previous vote log and comment after vote cancelled

### DIFF
--- a/mbbsd/vote.c
+++ b/mbbsd/vote.c
@@ -478,6 +478,10 @@ vote_view(const vote_buffer_t *vbuf, const char *bname)
 	unlink(buf);
 	setbfile(buf, bname, vbuf->title);
 	unlink(buf);
+	setbfile(buf, bname, vbuf->logs);
+	unlink(buf);
+	setbfile(buf, bname, vbuf->comments);
+	unlink(buf);
 
 	if (fhp->bvote > 0)
 	    fhp->bvote--;


### PR DESCRIPTION
Before this fix, the results of newer vote will preserve last cancelled vote's logs and comments
that may contains voter's information.

This fix will do same things as other vote's infomation(title, description)
after vote cancelled, that is, remove unnecessary file.

- Thanks @sitos for providing this patch

## Test Results (Manaully)

- before patched: https://gist.github.com/holishing/c20c21ea41204851d5da01c1a46d7b29
- after patched: https://gist.github.com/holishing/bebf788ded8bd01cd5f9f1c3f7e17b12