### PR TITLE
Support multiple account verification methods

### DIFF
--- a/daemon/regmaild/regmailc.c
+++ b/daemon/regmaild/regmailc.c
@@ -21,11 +21,69 @@ read_int_reply(int fd)
     return true;
 }
 
+static bool
+read_verifydb_count_reply(int fd)
+{
+    verifydb_count_rep rep;
+    if (toread(fd, &rep, sizeof(rep)) != sizeof(rep)) {
+	perror("toread");
+	return false;
+    }
+    if (rep.cb != sizeof(rep)) {
+	fprintf(stderr, "unable to read reply: cb != sizeof(rep): %lu != %lu\n",
+		rep.cb, sizeof(rep));
+	return false;
+    }
+    printf("status: %d\n", rep.status);
+    printf("count_self: %d\n", rep.count_self);
+    printf("count_other: %d\n", rep.count_other);
+    return true;
+}
+
+static bool
+read_verifydb_get_reply(int fd)
+{
+    verifydb_get_rep rep;
+    if (toread(fd, &rep, sizeof(rep)) != sizeof(rep)) {
+	perror("toread");
+	return false;
+    }
+    if (rep.cb != sizeof(rep)) {
+	fprintf(stderr, "unable to read reply: cb != sizeof(rep): %lu != %lu\n",
+		rep.cb, sizeof(rep));
+	return false;
+    }
+    printf("status: %d\n", rep.status);
+    printf("num_entries: %lu\n", rep.num_entries);
+    printf("entry_size: %lu\n", rep.entry_size);
+
+    verifydb_entry ent;
+    if (rep.entry_size != sizeof(ent)) {
+	fprintf(stderr, "unable to read entry: entry_size != sizeof(ent): %lu != %lu\n",
+		rep.entry_size, sizeof(ent));
+	return false;
+    }
+    for (size_t i = 0; i < rep.num_entries; i++) {
+	if (toread(fd, &ent, sizeof(ent)) != sizeof(ent)) {
+	    perror("toread");
+	    return false;
+	}
+	printf("record [%lu]\n", i);
+	printf("  timestamp: %ld\n", ent.timestamp);
+	printf("  vmethod: %d\n", ent.vmethod);
+	printf("  vkey: %s\n", ent.vkey);
+    }
+    return true;
+}
+
 static int
 usage(const char *prog)
 {
     fprintf(stderr, "Usage: %s table operation [args ...]\n\n", prog);
     fprintf(stderr, "\t%s regmaildb <count|set|amb> userid email\n", prog);
+    fprintf(stderr, "\t%s verifydb count userid generation vmethod vkey\n", prog);
+    fprintf(stderr, "\t%s verifydb set userid generation vmethod vkey\n", prog);
+    fprintf(stderr, "\t%s verifydb get userid generation [vmethod]\n", prog);
     return 1;
 }
 
@@ -34,6 +92,7 @@ int main(int argc, char **argv)
     const char *prog = argv[0];
     int fd;
     regmaildb_req_storage storage = {};
+    bool (*read_reply)(int fd) = read_int_reply;
 
     if (argc < 3)
 	return usage(prog);
@@ -70,6 +129,45 @@ int main(int argc, char **argv)
 	else
 	    return usage(prog);
     }
+    else if (strcmp(table, "verifydb") == 0)
+    {
+	if (argc < 5)
+	    return usage(prog);
+	const char *userid = argv[3];
+	const int64_t generation = atoll(argv[4]);
+	const int32_t vmethod = argc >= 6 ? atoi(argv[5]) : VMETHOD_UNSET;
+	const char *vkey = argc >= 7 ? argv[6] : NULL;
+	verifydb_req *req = &storage.verifydb;
+	req->cb = sizeof(*req);
+
+	// Common fields.
+	strlcpy(req->userid, userid, sizeof(req->userid));
+	req->generation = generation;
+	req->vmethod = vmethod;
+	if (vkey)
+	    strlcpy(req->vkey, vkey, sizeof(req->vkey));
+
+	if (strcmp(operation, "count") == 0)
+	{
+	    if (!vkey)
+		return usage(prog);
+	    req->operation = VERIFYDB_REQ_COUNT;
+	    read_reply = read_verifydb_count_reply;
+	}
+	else if (strcmp(operation, "set") == 0)
+	{
+	    if (!vkey)
+		return usage(prog);
+	    req->operation = VERIFYDB_REQ_SET;
+	}
+	else if (strcmp(operation, "get") == 0)
+	{
+	    req->operation = VERIFYDB_REQ_GET;
+	    read_reply = read_verifydb_get_reply;
+	}
+	else
+	    return usage(prog);
+    }
     else
     {
 	return usage(prog);
@@ -85,7 +183,7 @@ int main(int argc, char **argv)
 	return 1;
     }
 
-    if (!read_int_reply(fd)) {
+    if (!read_reply(fd)) {
 	fprintf(stderr, "failed to read reply\n");
 	return 1;
     }

--- a/daemon/regmaild/regmaild.c
+++ b/daemon/regmaild/regmaild.c
@@ -383,7 +383,7 @@ end:
 }
 
 static void
-verifydb_count(const verifydb_req *req, verifydb_count_rep *rep)
+verifydb_count_handler(const verifydb_req *req, verifydb_count_rep *rep)
 {
     sqlite3 *Db = g_Db;
     sqlite3_stmt *Stmt = NULL;
@@ -443,7 +443,7 @@ end:
 }
 
 static int
-verifydb_set(const verifydb_req *req)
+verifydb_set_handler(const verifydb_req *req)
 {
     int ret = VERIFYDB_ERROR;
 
@@ -491,7 +491,7 @@ end:
 }
 
 static void
-verifydb_get(const verifydb_req *req, int fd)
+verifydb_get_handler(const verifydb_req *req, int fd)
 {
     sqlite3 *Db = g_Db;
     sqlite3_stmt *Stmt = NULL;
@@ -963,7 +963,7 @@ client_cb(int fd, short event, void *arg)
                 goto end;
 
             verifydb_count_rep rep = {};
-            verifydb_count(req, &rep);
+            verifydb_count_handler(req, &rep);
             fprintf(stderr, "verifydb count: %s generation [%ld] vmethod [%d] vkey [%s] "
                     "(status: %d, self: %d, other %d)\n",
                     req->userid, req->generation, req->vmethod, req->vkey,
@@ -979,7 +979,7 @@ client_cb(int fd, short event, void *arg)
             if (!validate_verifydb_request(req))
                 goto end;
 
-            int ret = verifydb_set(req);
+            int ret = verifydb_set_handler(req);
             fprintf(stderr, "verifydb set: %s generation [%ld] vmethod [%d] vkey [%s] (status: %d)\n",
                     req->userid, req->generation, req->vmethod, req->vkey, ret);
             if (towrite(fd, &ret, sizeof(ret)) != sizeof(ret))
@@ -993,7 +993,7 @@ client_cb(int fd, short event, void *arg)
             if (!validate_verifydb_request(req))
                 goto end;
 
-            verifydb_get(req, fd);
+            verifydb_get_handler(req, fd);
             break;
         }
 

--- a/daemon/regmaild/regmaild.c
+++ b/daemon/regmaild/regmaild.c
@@ -859,10 +859,13 @@ validate_verifydb_request(const verifydb_req *req)
                 req->operation);
         return false;
     }
-    if (!*req->userid) {
-        fprintf(stderr, "invalid request: op=[%d], empty userid\n",
-                req->operation);
-        return false;
+    if (req->operation == VERIFYDB_REQ_GET ||
+        req->operation == VERIFYDB_REQ_SET) {
+        if (!*req->userid) {
+            fprintf(stderr, "invalid request: op=[%d], empty userid\n",
+                    req->operation);
+            return false;
+        }
     }
     if (req->operation == VERIFYDB_REQ_COUNT ||
         req->operation == VERIFYDB_REQ_SET) {

--- a/include/daemons.h
+++ b/include/daemons.h
@@ -65,7 +65,8 @@ typedef struct
 
 // verifydb vmethod keys. Data persisted to database. Do not change value.
 typedef enum {
-    VMETHOD_UNSET = 0
+    VMETHOD_UNSET = 0,
+    VMETHOD_EMAIL = 1
 } verifydb_vmethod_t;
 
 typedef struct {

--- a/include/daemons.h
+++ b/include/daemons.h
@@ -1,6 +1,7 @@
 #ifndef BBS_DAEMONS_H
 #define BBS_DAEMONS_H
 
+#include "fnv_hash.h"
 #include "pttstruct.h"
 
 ///////////////////////////////////////////////////////////////////////

--- a/include/daemons.h
+++ b/include/daemons.h
@@ -24,7 +24,8 @@ enum {
     REGCHECK_REQ_AMBIGUOUS,
 
     // Counts number of uses on (vmethod, vkey).
-    // User info is to separate count into self and others.
+    // User info is to separate count into self and others. If userid is empty,
+    // it counts every entry as others.
     //
     // Request: verifydb_req
     // Requires: userid, generation, vmethod, vkey

--- a/include/proto.h
+++ b/include/proto.h
@@ -235,6 +235,10 @@ int emaildb_update_email(const char *userid, const char *email);
 #ifdef USE_REGCHECKD
 int regcheck_ambiguous_userid_exist(const char *userid);
 #endif
+#ifdef USE_VERIFYDB
+int verifydb_count(const char *userid, int64_t generation, int32_t vmethod, const char *vkey, void *rep);
+int verifydb_set(const char *userid, int64_t generation, int32_t vmethod, const char *vkey);
+#endif
 
 /* fav */
 void fav_set_old_folder(fav_t *fp);

--- a/mbbsd/emaildb.c
+++ b/mbbsd/emaildb.c
@@ -83,4 +83,44 @@ int regcheck_ambiguous_userid_exist(const char *userid)
 
 #endif
 
+#ifdef USE_VERIFYDB
+
+int verifydb_count(const char *userid, int64_t generation,
+        int32_t vmethod, const char *vkey, void *rep)
+{
+    verifydb_req req = {};
+    req.cb = sizeof(req);
+    req.operation = VERIFYDB_REQ_COUNT;
+    if (userid)
+        strlcpy(req.userid, userid, sizeof(req.userid));
+    req.generation = generation;
+    req.vmethod = vmethod;
+    if (vkey)
+        strlcpy(req.vkey, vkey, sizeof(req.vkey));
+
+    return regmail_transact(&req, sizeof(req), rep, sizeof(verifydb_count_rep));
+}
+
+int verifydb_set(const char *userid, int64_t generation,
+        int32_t vmethod, const char *vkey)
+{
+    verifydb_req req = {};
+    req.cb = sizeof(req);
+    req.operation = VERIFYDB_REQ_SET;
+    if (userid)
+        strlcpy(req.userid, userid, sizeof(req.userid));
+    req.generation = generation;
+    req.vmethod = vmethod;
+    if (vkey)
+        strlcpy(req.vkey, vkey, sizeof(req.vkey));
+
+    int status;
+    int r = regmail_transact(&req, sizeof(req), &status, sizeof(status));
+    if (r < 0)
+        return r;
+    return status;
+}
+
+#endif
+
 // vim:et

--- a/mbbsd/emaildb.c
+++ b/mbbsd/emaildb.c
@@ -10,6 +10,10 @@ int emaildb_check_email(const char * userid, const char * email)
     int fd = -1;
     regmaildb_req req = {0};
 
+    // regmaild rejects empty userid, use a dummy value if there isn't one yet.
+    if (!userid)
+        userid = "-";
+
     // initialize request
     req.cb = sizeof(req);
     req.operation = REGMAILDB_REQ_COUNT;

--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -1,5 +1,6 @@
 #define PWCU_IMPL
 #include "bbs.h"
+#include "daemons.h"
 
 #define FN_REGISTER_LOG  "register.log"	// global registration history
 #define FN_REJECT_NOTIFY "justify.reject"
@@ -38,10 +39,13 @@
 #define REGISTER_ERR_CANCEL (-4)
 
 static int
-register_email_input(const char *userid, char *email);
+register_email_input(const userec_t *u, char *email);
 
 static int
-register_check_and_update_emaildb(const char *userid, const char *email);
+register_count_email(const userec_t *u, const char *email);
+
+static int
+register_check_and_update_emaildb(const userec_t *u, const char *email);
 
 ////////////////////////////////////////////////////////////////////////////
 // Value Validation
@@ -991,7 +995,7 @@ new_register(void)
 
     // Mark register complete after the user has been created.
     if (email_verified) {
-	if (register_check_and_update_emaildb(newuser.userid, newuser.email) ==
+	if (register_check_and_update_emaildb(&newuser, newuser.email) ==
 		REGISTER_OK) {
 	    char justify[sizeof(newuser.justify)];
 	    snprintf(justify, sizeof(justify), "<E-Mail>: %s", Cdate(&now));
@@ -1286,7 +1290,7 @@ create_regform_request()
 }
 
 static int
-register_email_input(const char *userid, char *email)
+register_email_input(const userec_t *u, char *email)
 {
     while (1) {
 	email[0] = 0;
@@ -1298,23 +1302,19 @@ register_email_input(const char *userid, char *email)
 	if (strcmp(email, "x") == 0)
 	    return REGISTER_OK;
 
-	if (!check_regmail(email))
-	    return REGISTER_ERR_INVALID_EMAIL;
-
-#ifdef USE_EMAILDB
-	int email_count;
-
 	// before long waiting, alert user
 	move(18, 0); clrtobot();
 	outs("正在確認 email, 請稍候...\n");
 	doupdate();
 
-	email_count = emaildb_check_email(userid, email);
+	if (!check_regmail(email))
+	    return REGISTER_ERR_INVALID_EMAIL;
+
+	int email_count = register_count_email(u, email);
 	if (email_count < 0)
 	    return REGISTER_ERR_EMAILDB;
 	if (email_count >= EMAILDB_LIMIT)
 	    return REGISTER_ERR_TOO_MANY_ACCOUNTS;
-#endif
 
 	move(17, 0);
 	outs(ANSI_COLOR(1;31)
@@ -1330,18 +1330,63 @@ register_email_input(const char *userid, char *email)
 }
 
 static int
-register_check_and_update_emaildb(const char *userid, const char *email)
+register_count_email(const userec_t *u, const char *email)
 {
+    const char *userid = u ? u->userid : NULL;
+    int count = 0;
+
 #ifdef USE_EMAILDB
-    int email_count = emaildb_check_email(userid, email);
+    {
+	int r = emaildb_check_email(userid, email);
+	if (r < 0)
+	    return -1;
+	if (count < r)
+	    count = r;
+    }
+#endif
+
+#ifdef USE_VERIFYDB
+    {
+	char lcemail[EMAILSZ];
+	str_lower(lcemail, email);
+
+	const int64_t generation = u ? u->firstlogin : 0;
+
+	verifydb_count_rep rep;
+	int r = verifydb_count(userid, generation, VMETHOD_EMAIL, lcemail, &rep);
+	if (r != 0)
+	    return -1;
+	if (count < rep.count_other)
+	    count = rep.count_other;
+    }
+#endif
+
+    return count;
+}
+
+static int
+register_check_and_update_emaildb(const userec_t *u, const char *email)
+{
+    assert(u);
+
+    int email_count = register_count_email(u, email);
     if (email_count < 0)
 	return REGISTER_ERR_EMAILDB;
     if (email_count >= EMAILDB_LIMIT)
 	return REGISTER_ERR_TOO_MANY_ACCOUNTS;
 
+#ifdef USE_EMAILDB
     if (emaildb_update_email(cuser.userid, email) < 0)
 	return REGISTER_ERR_EMAILDB;
 #endif
+
+#ifdef USE_VERIFYDB
+    char lcemail[EMAILSZ];
+    str_lower(lcemail, email);
+    if (verifydb_set(u->userid, u->firstlogin, VMETHOD_EMAIL, lcemail) != 0)
+	return REGISTER_ERR_EMAILDB;
+#endif
+
     return REGISTER_OK;
 }
 
@@ -1372,10 +1417,10 @@ toregister(char *email)
 
     int err;
     do {
-	err = register_email_input(cuser.userid, email);
+	err = register_email_input(&cuser, email);
 
 	if (err == REGISTER_OK && strcasecmp(email, "x") != 0)
-	    err = register_check_and_update_emaildb(cuser.userid, email);
+	    err = register_check_and_update_emaildb(&cuser, email);
 
 	switch (err) {
 	    case REGISTER_OK:

--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -645,9 +645,7 @@ new_register_email_verify(char *email)
 	    return REGISTER_ERR_CANCEL;
 	}
 
-	// Use "-" for userid, regmaild rejects empty userid, which we don't
-	// really have a userid yet.
-	err = register_email_input("-", email);
+	err = register_email_input(NULL, email);
 	switch (err) {
 	    case REGISTER_OK:
 		if (strcasecmp(email, "x") != 0)

--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -1002,28 +1002,32 @@ new_register(void)
     }
 }
 
-int
-check_regmail(char *email)
+bool
+check_email_allow_reject_lists(char *email, const char **errmsg, const char **notice_file)
 {
     FILE           *fp;
     char            buf[128], *c;
-    int allow = 0;
+    bool allow;
+
+    if (errmsg)
+	*errmsg = NULL;
+    if (notice_file)
+	*notice_file = NULL;
 
     c = strchr(email, '@');
-    if (c == NULL) return 0;
 
-    // reject multiple '@'
-    if (c != strrchr(email, '@'))
+    // reject no '@' or multiple '@'
+    if (c == NULL || c != strrchr(email, '@'))
     {
-	vmsg("E-Mail 的格式不正確。");
-	return 0;
+	if (errmsg) *errmsg = "E-Mail 的格式不正確。";
+	return false;
     }
 
     // domain tolower
     str_lower(c, c);
 
     // allow list
-    allow = 0;
+    allow = false;
     if ((fp = fopen("etc/whitemail", "rt")))
     {
 	while (fgets(buf, sizeof(buf), fp)) {
@@ -1034,10 +1038,10 @@ check_regmail(char *email)
 	    // vmsgf("%c %s %s",buf[0], c, email);
 	    switch(buf[0])
 	    {
-		case 'A': if (strcasecmp(c, email) == 0)	allow = 1; break;
-		case 'P': if (strcasestr(email, c))	allow = 1; break;
-		case 'S': if (strcasecmp(strstr(email, "@") + 1, c) == 0) allow = 1; break;
-		case '%': allow = 1; break; // allow all
+		case 'A': if (strcasecmp(c, email) == 0)	allow = true; break;
+		case 'P': if (strcasestr(email, c))	allow = true; break;
+		case 'S': if (strcasecmp(strstr(email, "@") + 1, c) == 0) allow = true; break;
+		case '%': allow = true; break; // allow all
 	        // domain match (*@c | *@*.c)
 		case 'D': if (strlen(email) > strlen(c))
 			  {
@@ -1047,7 +1051,7 @@ check_regmail(char *email)
 				  break;
 			      c2--;
 			      if (*c2 == '.' || *c2 == '@')
-				  allow = 1;
+				  allow = true;
 			  }
 			  break;
 	    }
@@ -1056,20 +1060,16 @@ check_regmail(char *email)
 	fclose(fp);
 	if (!allow)
 	{
-	    // show whitemail notice if it exists.
-	    if (dashf(FN_NOTIN_WHITELIST_NOTICE))
-	    {
-		VREFSCR scr = vscr_save();
-		more(FN_NOTIN_WHITELIST_NOTICE, NA);
-		pressanykey();
-		vscr_restore(scr);
-	    } else vmsg("抱歉，目前不接受此 Email 的註冊申請。");
-	    return 0;
+	    if (notice_file && dashf(FN_NOTIN_WHITELIST_NOTICE))
+		*notice_file = FN_NOTIN_WHITELIST_NOTICE;
+	    if (errmsg)
+		*errmsg = "抱歉，目前不接受此 Email 的註冊申請。";
+	    return false;
 	}
     }
 
     // reject list
-    allow = 1;
+    allow = true;
     if ((fp = fopen("etc/banemail", "r"))) {
 	while (allow && fgets(buf, sizeof(buf), fp)) {
 	    if (buf[0] == '#')
@@ -1080,21 +1080,24 @@ check_regmail(char *email)
 	    {
 		case 'A': if (strcasecmp(c, email) == 0)
 			  {
-			      allow = 0;
+			      allow = false;
 			      // exact match
-			      vmsg("此電子信箱已被禁止註冊");
+			      if (errmsg)
+				  *errmsg = "此電子信箱已被禁止註冊";
 			  }
 			  break;
 		case 'P': if (strcasestr(email, c))
 			  {
-			      allow = 0;
-			      vmsg("此信箱已被禁止用於註冊 (可能是免費信箱)");
+			      allow = false;
+			      if (errmsg)
+				*errmsg = "此信箱已被禁止用於註冊 (可能是免費信箱)";
 			  }
 			  break;
 		case 'S': if (strcasecmp(strstr(email, "@") + 1, c) == 0)
 			  {
-			      allow = 0;
-			      vmsg("此信箱已被禁止用於註冊 (可能是免費信箱)");
+			      allow = false;
+			      if (errmsg)
+				  *errmsg = "此信箱已被禁止用於註冊 (可能是免費信箱)";
 			  }
 			  break;
 		case 'D': if (strlen(email) > strlen(c))
@@ -1106,8 +1109,9 @@ check_regmail(char *email)
 			      c2--;
 			      if (*c2 == '.' || *c2 == '@')
 			      {
-				  vmsg("此信箱的網域已被禁止用於註冊 (可能是免費信箱)");
-				  allow = 0;
+				  allow = false;
+				  if (errmsg)
+				      *errmsg = "此信箱的網域已被禁止用於註冊 (可能是免費信箱)";
 			      }
 			  }
 			  break;
@@ -1116,6 +1120,26 @@ check_regmail(char *email)
 	fclose(fp);
     }
     return allow;
+}
+
+int
+check_regmail(char *email)
+{
+    const char *errmsg, *notice_file;
+    bool allow = check_email_allow_reject_lists(email, &errmsg, &notice_file);
+    if (allow)
+	return 1;
+
+    // show whitemail notice if it exists.
+    if (notice_file) {
+	VREFSCR scr = vscr_save();
+	more(notice_file, NA);
+	pressanykey();
+	vscr_restore(scr);
+    } else if (errmsg) {
+	vmsg(errmsg);
+    }
+    return 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -628,14 +628,13 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
     char	    pre_confirmed = 0;
     int y = 0;
     int perm_changed;
-    int mail_changed;
     int money_changed;
     int tokill = 0;
     int changefrom = 0;
     int xuid;
 
     fail = 0;
-    mail_changed = money_changed = perm_changed = 0;
+    money_changed = perm_changed = 0;
 
     // verify unum
     xuid = getuser(orig_uid, &x);
@@ -662,13 +661,13 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
     }
 
     ans = vans(adminmode ?
-    "(1)改資料(2)密碼(3)權限(4)砍帳(5)改ID(6)寵物(7)審判(8)退文(M)信箱 [0]結束 " :
+    "(1)改資料(2)密碼(3)權限(4)砍帳(5)改ID(6)寵物(7)審判(8)退文 [0]結束 " :
     "請選擇 (1)修改資料 (2)設定密碼 (C)個人化設定 [0]結束 ");
 
     if (ans > '2' && ans != 'c' && !adminmode)
 	ans = '0';
 
-    if (ans == '1' || ans == '3' || ans == 'm') {
+    if (ans == '1' || ans == '3') {
 	clear();
 	y = 1;
 	move(y++, 0);
@@ -676,7 +675,7 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
 	outs(x.userid);
     }
 
-    if (adminmode && ((ans >= '1' && ans <= '8') || ans == 'm') &&
+    if (adminmode && (ans >= '1' && ans <= '8') &&
 	search_ulist(unum))
     {
 	if (vans("使用者目前正在線上，修改資料會先踢下線。確定要繼續嗎？ (y/N): ")
@@ -693,63 +692,6 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
 	if (!adminmode)
 	    Customize();
 	return;
-
-    case 'm':
-	while (1) {
-	    getdata_str(y, 0,
-                    adminmode ? "E-Mail (站長變更不需認證): " :
-                                "電子信箱 [變動要重新認證]：",
-                    buf, sizeof(x.email), DOECHO, x.email);
-
-	    strip_blank(buf, buf);
-
-	    // fast break
-	    if (!buf[0] || strcasecmp(buf, "x") == 0)
-		break;
-
-	    if (!check_regmail(buf))
-		continue;
-
-	    // XXX 這裡也要 emaildb_check
-#ifdef USE_EMAILDB
-	    {
-		int email_count = emaildb_check_email(cuser.userid, buf);
-
-		if (email_count < 0)
-		    vmsg("暫時不允許\ email 認證, 請稍後再試");
-		else if (email_count >= EMAILDB_LIMIT)
-		    vmsg("指定的 E-Mail 已註冊過多帳號, 請使用其他 E-Mail");
-		else
-		    break; // valid mail
-		// invalid mail
-		continue;
-	    }
-#endif
-	    // valid mail.
-	    break;
-	}
-	y++;
-
-	// admins may want to use special names
-	if (buf[0] &&
-		strcmp(buf, x.email) &&
-		(strchr(buf, '@') || adminmode)) {
-
-	    // TODO 這裡也要 emaildb_check
-#ifdef USE_EMAILDB
-	    if (emaildb_update_email(x.userid, buf) < 0) {
-		vmsg("暫時不允許\ email 認證, 請稍後再試");
-		break;
-	    }
-#endif
-	    strlcpy(x.email, buf, sizeof(x.email));
-	    mail_changed = 1;
-
-            //  XXX delregcodefile 會看 cuser.userid...
-            if (!adminmode)
-                delregcodefile();
-	}
-	break;
 
     case '1':
 	move(0, 0);
@@ -1198,10 +1140,6 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
 	snprintf(title, sizeof(title), "變更ID: %s -> %s (站長: %s)",
 		 orig_uid, x.userid, cuser.userid);
 	post_msg(BN_SECURITY, title, title, "[系統安全局]");
-    }
-    if (mail_changed && !adminmode) {
-	// wait registration.
-	x.userlevel &= ~(PERM_LOGINOK | PERM_POST);
     }
 
     if (tokill) {


### PR DESCRIPTION
**A new `verifydb` table served by `regmaild` that stores unique verification key.**

The current `emaildb` table stores `userid` and `email` only. Since `userid` may be reused after it expires, the server determines whether the entry is up-to-date by comparing `email` with the one in passwd file.

As `userec_t` is full, we can't add more fields to support other verification methods. (i.e. no comparing with passwd file) The new `verifydb` table uses `(userid, generation)` to identify each user. `generation` is the `firstlogin` field in `userec_t`.

To support multiple verification at the same, PK is set to `(userid, generation, vmethod)`.

Email is now dual-write to verifydb.
