### PR TITLE
wsproxy: Substitute LuaJIT built-in library `ffi` for external library `vstruct`

### DIFF
--- a/daemon/wsproxy/README.md
+++ b/daemon/wsproxy/README.md
@@ -2,10 +2,6 @@
 
 The websocket to telnet bbs proxy.
 
-## Dependency
-
-- [vstruct](https://github.com/toxicfrog/vstruct/) -- Lua library for binary manipulation.
-
 ## Install
 
 - Install OpenResty.
@@ -13,18 +9,9 @@ The websocket to telnet bbs proxy.
 Follow the [installation instruction](https://openresty.org/en/installation.html) on the OpenResty
 official website.
 
-- Download vstruct
-
-```
-$ cd ~bbs/pttbbs/daemon/wsproxy && mkdir lib && cd lib
-$ git clone https://github.com/toxicfrog/vstruct/
-```
-
 - Configure nginx
 
 ```nginx
-lua_package_path ";;/home/bbs/pttbbs/daemon/wsproxy/lib/?.lua;/home/bbs/pttbbs/daemon/wsproxy/lib/?/init.lua";
-
 map $http_origin $bbs_origin_checked {
     "http://www.ptt.cc" 1;
     "https://www.ptt.cc" 1;

--- a/daemon/wsproxy/wsproxy.lua
+++ b/daemon/wsproxy/wsproxy.lua
@@ -33,7 +33,7 @@ local bbs_receive_size = 1024
 -- response code back.
 local ngx_close_conn_code = 444
 
-local check_origin = function ()
+local function check_origin()
     local checked = tonumber(ngx.var.bbs_origin_checked)
     if checked ~= 1 then
         ngx.log(ngx.ERR, "origin checked failed: ", ngx.req.get_headers().origin)
@@ -41,7 +41,7 @@ local check_origin = function ()
     end
 end
 
-local build_conn_data = function ()
+local function build_conn_data()
     local fmt = vstruct.compile("< u4 u4 u4 s16 u2 u2 u4")
     local flags = 0
     local bbs_lport = tonumber(ngx.var.bbs_lport)
@@ -60,7 +60,7 @@ local build_conn_data = function ()
     })
 end
 
-local connect_mbbsd = function ()
+local function connect_mbbsd()
     local addr = ngx.var.bbs_logind_addr
     if not addr then
         ngx.log(ngx.ERR, "bbs_logind_addr not set")
@@ -83,7 +83,7 @@ local connect_mbbsd = function ()
     return mbbsd
 end
 
-local start_websocket_server = function ()
+local function start_websocket_server()
     local ws, err = server:new({
         timeout = timeout_ms,
         max_payload_len = 65535,
@@ -95,7 +95,7 @@ local start_websocket_server = function ()
     return ws
 end
 
-local ws2sock = function (ws, sock)
+local function ws2sock(ws, sock)
     local last_typ = ""
     while true do
         local data, typ, err = ws:recv_frame()
@@ -141,7 +141,7 @@ local ws2sock = function (ws, sock)
     end
 end
 
-local sock2ws = function (sock, ws)
+local function sock2ws(sock, ws)
     while true do
         sock:settimeout(timeout_ms)
         local data, err = sock:receiveany(bbs_receive_size)
@@ -161,7 +161,7 @@ local sock2ws = function (sock, ws)
     end
 end
 
-local main = function ()
+local function main()
     check_origin()
 
     -- Start websocket first to make protocol-level dos harder.


### PR DESCRIPTION
Recent OpenResty versions use LuaJIT since the `receiveany()` method was introduced.

LuaJIT has a built-in `ffi` library (<http://luajit.org/ext_ffi.html>), which can be used to replace the external `vstruct` library currently in use.

wsproxy was ported to DreamBBS (<https://term.ccns.cc>) (a Maple3-derived BBS), and these commits have been tested there (<https://github.com/ccns/dreambbs/commits/master/scripts/wsproxy>).