### PR TITLE
Makefiles: let libraries in common/fbs be compiled optionally

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,3 +1,10 @@
-SUBDIR:=	bbs fbs osdep sys
+SRCROOT=        ..
+.include "$(SRCROOT)/pttbbs.mk"
+
+SUBDIR:=	bbs osdep sys
+
+.if $(USE_MBBSD_CXX)
+SUBDIR+=	fbs
+.endif
 
 .include <bsd.subdir.mk>

--- a/mbbsd/Makefile
+++ b/mbbsd/Makefile
@@ -51,15 +51,10 @@ LDLIBS:= -lcmbbs -lcmsys -losdep $(LDLIBS)
 # conditional configurations and optional modules
 #######################################################################
 
-BBSCONF:=	$(SRCROOT)/pttbbs.conf
-DEF_PATTERN:=	^[ \t]*\#[ \t]*define[ \t]*
-DEF_CMD:=	grep -Ewq "${DEF_PATTERN}"
-DEF_YES:=	&& echo "YES" || echo ""
 USE_BBSLUA!=  	sh -c '${DEF_CMD}"USE_BBSLUA" ${BBSCONF} ${DEF_YES}'
 USE_PFTERM!=	sh -c '${DEF_CMD}"USE_PFTERM" ${BBSCONF} ${DEF_YES}'
 USE_NIOS!=	sh -c '${DEF_CMD}"USE_NIOS"   ${BBSCONF} ${DEF_YES}'
 USE_CONVERT!=	sh -c '${DEF_CMD}"CONVERT"    ${BBSCONF} ${DEF_YES}'
-USE_MBBSD_CXX!=	sh -c '${DEF_CMD}"USE_MBBSD_CXX" ${BBSCONF} ${DEF_YES}'
 
 .if $(USE_BBSLUA)
 .if $(OSTYPE)=="FreeBSD"

--- a/pttbbs.mk
+++ b/pttbbs.mk
@@ -102,6 +102,15 @@ CXXFLAGS+=	-DNO_FORK
 ######################################
 # Settings for common libraries
 
+#######################################################################
+# conditional configurations and optional modules
+#######################################################################
+
+BBSCONF:=       $(SRCROOT)/pttbbs.conf
+DEF_PATTERN:=   ^[ \t]*\#[ \t]*define[ \t]*
+DEF_CMD:=       grep -Ewq "${DEF_PATTERN}"
+DEF_YES:=       && echo "YES" || echo ""
+
 #libevent
 LIBEVENT_CFLAGS!=	pkg-config --cflags libevent
 LIBEVENT_LIBS_L!=	pkg-config --libs-only-L libevent
@@ -119,6 +128,10 @@ NOGCCERROR:=no
 
 # FreeBSD make
 WITHOUT_PROFILE:=yes
+
+# Apply conditional configurations for NetBSD Makefiles in commons/,
+# mbbsd/ or more directory
+USE_MBBSD_CXX!= sh -c '${DEF_CMD}"USE_MBBSD_CXX" ${BBSCONF} ${DEF_YES}'
 
 ######################################
 


### PR DESCRIPTION
Move definition detection methods for bmake/pmake
from `mbbsd/Makefile` to `pttbbs.mk`

Do **NOT** compile `common/fbs` (use `flatbuffers-compiler`(`flatc` command) as *build-dependencies*) when `USE_MBBSD_CXX` is **NOT** defined
for reducing necessary dependencies for normal community developers

tested when `USE_MBBSD_CXX`, `USE_EMAILDB` and `USE_VERIFYDB` was **NOT** enabled:
https://github.com/bbsdocker/imageptt/runs/1372213879

tested when `USE_MBBSD_CXX`, `USE_EMAILDB`  and `USE_VERIFYDB` was **enabled**:
https://github.com/bbsdocker/imageptt/runs/1372343068