### PR TITLE
common/sys/string.c: Fix `strip_nonebig5` ignoring the byte following `ff fd`

### DIFF
--- a/common/sys/string.c
+++ b/common/sys/string.c
@@ -276,15 +276,7 @@ strip_nonebig5(unsigned char *str, int maxlen)
   for(i=0;i<maxlen && str[i];i++) {
     if(32<=str[i] && str[i]<128)
       str[len++]=str[i];
-    else if(str[i]==255) {
-      if(i+1<maxlen)
-	if(251<=str[i+1] && str[i+1]<=254) {
-	  i++;
-	  if(i+1<maxlen && str[i+1])
-	    i++;
-	}
-      continue;
-    } else if(str[i]&0x80) {
+    else if(str[i]&0x80) {
       if(i+1<maxlen)
 	if((0x40<=str[i+1] && str[i+1]<=0x7e) ||
 	   (0xa1<=str[i+1] && str[i+1]<=0xfe)) {


### PR DESCRIPTION
This fixes #94.

According to `common/sys/big5.c`:
- Unicode code points without the corresponding Big5-UAO code point are always converted to `0xfffd` (see `u2b_table`).
- Big5-UAO code points `0xfeff`-`0xffff` are left unchanged when converted into Unicode (see `b2u_table`).

Consider the case for `strip_nonebig5`: `str` is `"\xff\xfdQ"` and `maxlen` > `3`.

When `i` is `0`, both `str[i]==255` and `251<=str[i+1] && str[i+1]<=254` hold, and the first `i++` following them skips the byte `\xff`.

`i+1<maxlen && str[i+1]` also holds, and the second `i++` skips the byte `\xfd`.

However, the `for` loop also performs `i++` after the `continue` and makes the byte `Q` ignored.

Therefore, the second `i++` is redundant and erroneous. It makes the byte following `"\xff\xfd"` ignored.