### PR TITLE
NOKILLWATERBALL: fix typo on comment

### DIFF
--- a/sample/pttbbs.conf
+++ b/sample/pttbbs.conf
@@ -200,7 +200,7 @@
 //#define SAFE_ARTICLE_DELETE
 
 /* 若定義, 則在傳送水球的時候, 不會直接 kill 該程序. 理論上可以減少大
-   量的系統負和                                                       */
+   量的系統負荷                                                       */
 //#define NOKILLWATERBALL
 
 /* 若定義, 則在系統超過負荷的時候, 新接的連線會留住 OVERLOADBLOCKFDS


### PR DESCRIPTION
Before:
/* 若定義, 則在傳送水球的時候, 不會直接 kill 該程序. 理論上可以減少大
   量的系統負和                                                       */
   
After:
/* 若定義, 則在傳送水球的時候, 不會直接 kill 該程序. 理論上可以減少大
   量的系統負荷                                                       */ 