### PR TITLE
Provided offset, we should use SEEK_SET in PttLock

### DIFF
--- a/common/sys/lock.c
+++ b/common/sys/lock.c
@@ -7,13 +7,13 @@
  * @param mode	F_WRLCK, F_UNLCK
  */
 void
-PttLock(int fd, int start, int size, int mode)
+PttLock(int fd, int offset, int size, int mode)
 {
     static struct flock lock_it;
     int             ret;
 
-    lock_it.l_whence = SEEK_CUR;/* from current point */
-    lock_it.l_start = start;	/* -"- */
+    lock_it.l_whence = SEEK_SET;/* provided offset, we should use SEEK_SET */
+    lock_it.l_start = offset;	/* -"- */
     lock_it.l_len = size;	/* length of data */
     lock_it.l_type = mode;	/* set exclusive/write lock */
     lock_it.l_pid = 0;		/* pid not actually interesting */


### PR DESCRIPTION
Found some functions use PttLock after lseek
but some use PttLock without lseek.
Provided offset, we should use SEEK_SET in PttLock.

The following lines use PttLock F_WRLCK:
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L84 (after lseek)
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L133 (after lseek)
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L195 (no lseek)
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L261 (no lseek)

The following lines use PttLock F_UNLCK:
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L86 (after lseek)
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L149 (after lseek)
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L223 (after lseek)
https://github.com/ptt/pttbbs/blob/master/common/sys/record.c#L275 (after lseek)

https://github.com/ptt/pttbbs/issues/100