### PR TITLE
Let Makefile compatible with current bmake and install newly added etc/ config for new BBS

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -7,4 +7,9 @@ SUBDIR:=	bbs osdep sys
 SUBDIR+=	fbs
 .endif
 
+all:
+
+install: all
+	@true
+
 .include <bsd.subdir.mk>

--- a/sample/etc/Makefile
+++ b/sample/etc/Makefile
@@ -5,6 +5,7 @@ INSTALLTAG=$(TARGET).installed
 FILES=	Welcome		Welcome_login	\
 	Logout		goodbye		bad_host 	today_boring	\
 	register	registered	registermail	registeredmail 	\
+	reg.methods	reg.sms.notes \
 	feast		sysop		banip.conf	\
 	ve.hlp		board.help	boardlist.help	\
 	editable	expire2.conf	domain_name_query.cidr	\


### PR DESCRIPTION
1. Let Makefile compatible with current bmake:
mk rules used in Debian `bmake` (Debian version <= 10) is legacy BSD-like make rules, ( [1] )
But nowadays Debian bmake maintainer is deprecating this and use upstream's mk files by default ( [2] )
In upstream bmake project, `bsd.*.mk` rules even directly linked to `*.mk`. ( [3], line 182 in mk/install-mk)

To be compatible with both mk versions as possible, we may adjust little details.

2. install newly added `etc/` config for new BBS:
* Enable register methods for New BBS by default
* Also install blank sms notes by default for furthur needs

[1]: https://salsa.debian.org/debian/bmake/-/tree/7a98c0c35bd4276514fe477adb95a45d1f94f69f/debian/mk
[2]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=986281
[3]: http://www.crufty.net/ftp/pub/sjg/mk-20210330.tar.gz