### PR TITLE
Supporting Ban Post or Comment outside Taiwanese IP

### DIFF
--- a/daemon/fromd/Makefile
+++ b/daemon/fromd/Makefile
@@ -15,7 +15,8 @@ FROMD_LDFLAGS = -levent
 .if ${ENABLE_MAXMIND_DB} == "y"
 CFLAGS += -DFROMD_USE_MAXMIND_DB
 FROMD_LDFLAGS += -lmaxminddb
-.elif ${ENABLE_GEOIP_DB} == "y"
+.endif
+.if ${ENABLE_GEOIP_DB} == "y"
 CFLAGS += -DFROMD_USE_GEOIP_DB
 FROMD_LDFLAGS += -lGeoIP
 .endif

--- a/include/proto.h
+++ b/include/proto.h
@@ -101,6 +101,9 @@ void log_crosspost_in_allpost(const char *brd, const fileheader_t *postfile);
 #ifdef USE_COOLDOWN
 int check_cooldown(boardheader_t *bp);
 #endif
+#ifdef POST_COMMENT_WITH_TAIWAN_IP_ONLY
+bool is_taiwan_ip();
+#endif
 
 /* board */
 #define setutmpbid(bid) currutmp->brc_id=bid;

--- a/include/pttstruct.h
+++ b/include/pttstruct.h
@@ -232,6 +232,9 @@ typedef struct boardheader_t { /* 256 bytes */
 #define BRD_ALIGNEDCMT		0x04000000	/* 對齊式的推文 */
 #define BRD_NOSELFDELPOST       0x08000000      /* 不可自刪 */
 #define BRD_BM_MASK_CONTENT	0x10000000	/* 允許板主刪除特定文字 */
+#ifdef POST_COMMENT_WITH_TAIWAN_IP_ONLY
+#define BRD_TAIWAN_IP_ONLY  0x20000000
+#endif // POST_COMMENT_WITH_TAIWAN_IP_ONLY
 
 // Board group linked-list type. Used for array index of firstchild and next.
 #define BRD_GROUP_LL_TYPE_NAME  (0)

--- a/mbbsd/bbs.c
+++ b/mbbsd/bbs.c
@@ -433,6 +433,23 @@ int IsFreeBoardName(const char *brdname)
     return 0;
 }
 
+#ifdef POST_COMMENT_WITH_TAIWAN_IP_ONLY
+/*
+ * Check if user ip address is from Taiwan
+ *
+ * This function will compare from_cc string and "Taiwan" in Chinese (Big5)
+ * from_cc will generate when user login bbs system, and set from FROMD
+ *
+ * Return true when user is from Taiwan IP, false when outside Taiwan
+ */
+bool
+is_taiwan_ip()
+{
+    // TODO: move this string to string table, eg: common.h
+    return !strncmp("»OÆW", from_cc, sizeof(from_cc));
+}
+#endif
+
 int
 CheckModifyPerm(const char **preason)
 {

--- a/mbbsd/board.c
+++ b/mbbsd/board.c
@@ -496,6 +496,13 @@ b_config(void)
 		(bp->brdattr & BRD_OVER18) ?
 		ANSI_COLOR(1) "禁止 " : "允許\ " );
 
+#ifdef POST_COMMENT_WITH_TAIWAN_IP_ONLY
+	prints( " " ANSI_COLOR(1;36) "t" ANSI_RESET
+		" - %s" ANSI_RESET "台灣IP發/推文\n",
+		(bp->brdattr & BRD_TAIWAN_IP_ONLY) ?
+		ANSI_COLOR(1) "限定 " : "不限定 " );
+#endif
+
 	if (!canpost)
 	    outs(ANSI_COLOR(1;31)"  ★ 您在此看板無發文或推文權限，"
 		"詳細原因請參考上面顯示為紅色或有 * 的項目。"ANSI_RESET"\n");
@@ -812,6 +819,13 @@ b_config(void)
 		    touched = 1;
 		}
 		break;
+
+#ifdef POST_COMMENT_WITH_TAIWAN_IP_ONLY
+		case 't':
+		bp->brdattr ^= BRD_TAIWAN_IP_ONLY;
+		touched = 1;
+		break;
+#endif // POST_COMMENT_WITH_TAIWAN_IP_ONLY
 
 	    case 'v':
 		clear();

--- a/mbbsd/cache.c
+++ b/mbbsd/cache.c
@@ -233,6 +233,12 @@ postperm_msg(const char *bname)
     assert(0<=i-1 && i-1<MAX_BOARD);
     bp = getbcache(i);
 
+#ifdef POST_COMMENT_WITH_TAIWAN_IP_ONLY
+    if (bp->brdattr & BRD_TAIWAN_IP_ONLY)
+        if (!is_taiwan_ip())
+            return "看板限定臺灣IP發/推文";
+#endif // POST_COMMENT_WITH_TAIWAN_IP_ONLY
+
     if (bp->brdattr & BRD_GUESTPOST)
         return NULL;
 

--- a/mbbsd/register_sms.cc
+++ b/mbbsd/register_sms.cc
@@ -348,7 +348,7 @@ void SmsValidation::Run() {
       vmsg("系統錯誤，請至 " BN_BUGREPORT " 看板回報");
       return;
     }
-    if (vans("請問您接受使用條款嗎? (Y/n) ") != 'y') {
+    if (vans("請問您接受使用條款嗎? (y/N) ") != 'y') {
       vmsg("操作取消");
       return;
     }

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -420,8 +420,8 @@ violate_law(userec_t * u, int unum)
 	passwd_sync_update(unum, u);
         if (*ans == '1' || *ans == '2')
             delete_allpost(u->userid);
-	post_violatelaw(u->userid, cuser.userid, reason, "罰單處份");
-	mail_violatelaw(u->userid, "站務警察", reason, "罰單處份");
+	post_violatelaw(u->userid, cuser.userid, reason, "罰單處分");
+	mail_violatelaw(u->userid, "站務警察", reason, "罰單處分");
     }
     pressanykey();
 }

--- a/sample/pttbbs.conf
+++ b/sample/pttbbs.conf
@@ -251,6 +251,9 @@
 /* 使用 daemon/fromd, 使用外部daemon紀錄上站故鄉名稱 */
 //#define FROMD
 
+/* 看板權限限制非台灣IP發/推文，開啟此設定必須開啟 FROMD */
+//#define POST_COMMENT_WITH_TAIWAN_IP_ONLY
+
 /* 若定義, 則不允許註冊 guest */
 //#define NO_GUEST_ACCOUNT_REG
 

--- a/util/bbsrf.c
+++ b/util/bbsrf.c
@@ -49,6 +49,17 @@ static int showbanfile(const char *filename)
     return fp ? 0 : -1;
 }
 
+static int checkload()
+{
+    if (cpuload(NULL) <= MAX_CPULOAD)
+	return 0;
+
+    fputs("系統過載, 請稍後再來\n", stdout);
+    sleep(10);
+
+    return 1;
+}
+
 int main(int argc, const char **argv)
 {
     int uid;
@@ -74,6 +85,10 @@ int main(int argc, const char **argv)
 
 
     if (!showbanfile(BAN_FILE)) {
+	return 1;
+    }
+
+    if (checkload()) {
 	return 1;
     }
 

--- a/util/reaper.c
+++ b/util/reaper.c
@@ -1,7 +1,8 @@
 #define _UTIL_C_
-#include "bbs.h"
 
-time4_t now;
+#include "bbs.h"
+#include "var.h"
+
 
 #undef MAX_GUEST_LIFE
 #undef MAX_LIFE

--- a/util/uhash_loader.c
+++ b/util/uhash_loader.c
@@ -1,12 +1,11 @@
 /* standalone uhash loader -- jochang */
 #include "bbs.h"
 #include "fnv_hash.h"
+#include "var.h"
 
 void userec_add_to_uhash(int n, userec_t *id, int onfly);
 void fill_uhash(int onfly);
 void load_uhash(void);
-
-SHM_t *SHM;
 
 int main()
 {

--- a/util/writemoney.c
+++ b/util/writemoney.c
@@ -1,9 +1,7 @@
 /* 把 SHM 中的 money 全部寫回 .PASSWDS */
 #define _UTIL_C_
 #include "bbs.h"
-
-time4_t now;
-extern SHM_t   *SHM;
+#include "var.h"
 
 int main()
 {


### PR DESCRIPTION
Requirement:
```
- 新增看板權限限制非台灣IP發/推文 (實作難度: 易)
  Please use the country value returned from `fromd`.
  Please guard this via a compile time flag.
```

Changes:
1. Introduce a new compiler flag `POST_COMMENT_WITH_TAIWAN_IP_ONLY` for this function.
2. Implement `is_taiwan_ip()` which determine if current user is from Taiwan IP.
3. Insert checking Taiwan IP into `const char * postperm_msg(const char *bname)`.
4. Introduce a board configuration `BRD_TAIWAN_IP_ONLY (0x2000000)` for this function.

Screenshots:
<img width="1002" alt="截圖 2022-03-08 下午8 04 53" src="https://user-images.githubusercontent.com/600238/157236961-ef73dd4a-3cc1-4c06-a92d-1467831ba7f3.png">
<img width="1014" alt="截圖 2022-03-08 下午8 05 12" src="https://user-images.githubusercontent.com/600238/157236982-e0e0afb1-beed-4b1d-899e-fc7b316caa26.png">
<img width="1037" alt="截圖 2022-03-08 下午8 05 50" src="https://user-images.githubusercontent.com/600238/157236993-f2a6659b-4993-4ba1-b1ff-7b5d44dd0072.png">

Remark:
* Please enable `FROMD` and flag `POST_COMMENT_WITH_TAIWAN_IP_ONLY` when use this function.

TODO:
* Changing `from_cc` to ISO code instead of Big-5 string.
* Review the post or comment checking flow and write the document.
