### PR TITLE
Support requiring user to pass SMS verification to post

### DIFF
--- a/include/proto.h
+++ b/include/proto.h
@@ -101,6 +101,7 @@ void log_crosspost_in_allpost(const char *brd, const fileheader_t *postfile);
 #ifdef USE_COOLDOWN
 int check_cooldown(boardheader_t *bp);
 #endif
+bool is_user_sms_verified();
 
 /* board */
 #define setutmpbid(bid) currutmp->brc_id=bid;

--- a/include/pttstruct.h
+++ b/include/pttstruct.h
@@ -232,6 +232,7 @@ typedef struct boardheader_t { /* 256 bytes */
 #define BRD_ALIGNEDCMT		0x04000000	/* 對齊式的推文 */
 #define BRD_NOSELFDELPOST       0x08000000      /* 不可自刪 */
 #define BRD_BM_MASK_CONTENT	0x10000000	/* 允許板主刪除特定文字 */
+#define BRD_NEEDS_SMS_VERIFICATION   0x20000000  /* 允許版主設定看板發文需完成過簡訊認證 */
 
 // Board group linked-list type. Used for array index of firstchild and next.
 #define BRD_GROUP_LL_TYPE_NAME  (0)

--- a/mbbsd/bbs.c
+++ b/mbbsd/bbs.c
@@ -433,6 +433,38 @@ int IsFreeBoardName(const char *brdname)
     return 0;
 }
 
+/*
+ * Check if user phone number is verified by sms
+ *
+ * This function check if current user has already register their
+ * phone number with verifydb library.
+ * The verify process is modified from verifydb_check_vmethod_unused.
+ * It will pass cuser.userid and cuser.firstlogin as parameters and search
+ * for the VMETHOD_SMS record.
+ *
+ * Please note that, ptt system might have two different users with the same userid,
+ * but this won't happen at the same time. Therefore. we need to use firstlogin as the second
+ * parameter. And, ptt only accept phone registrations from Taiwan since July 2021
+ * so we can simply verify it in database.
+ *
+ * Return true when user has verified phone, false when no register record
+ */
+bool
+is_user_sms_verified()
+{
+    Bytes buf;
+    const VerifyDb::GetReply *reply;
+    if (!verifydb_getuser(cuser.userid, cuser.firstlogin, &buf, &reply)) {
+        // The verifydb may occur some problem, maybe we should log it and
+        // notify SYSOP?
+        return false;
+    }
+    if (verifydb_find_vmethod(reply, VMETHOD_SMS)) {
+        return true;
+    }
+    return false;
+}
+
 int
 CheckModifyPerm(const char **preason)
 {

--- a/mbbsd/board.c
+++ b/mbbsd/board.c
@@ -484,6 +484,11 @@ b_config(void)
 		(bp->brdattr & BRD_OVER18) ?
 		ANSI_COLOR(1) "禁止 " : "允許\ " );
 
+	prints( " " ANSI_COLOR(1;36) "t" ANSI_RESET
+		" - %s" ANSI_RESET "已驗證台灣門號發/推文\n",
+		(bp->brdattr & BRD_NEEDS_SMS_VERIFICATION) ?
+		ANSI_COLOR(1) "限定 " : "不限定 " );
+
 	if (!canpost)
 	    outs(ANSI_COLOR(1;31)"  ★ 您在此看板無發文或推文權限，"
 		"詳細原因請參考上面顯示為紅色或有 * 的項目。"ANSI_RESET"\n");
@@ -799,6 +804,11 @@ b_config(void)
 		    bp->brdattr ^= BRD_OVER18;
 		    touched = 1;
 		}
+		break;
+
+		case 't':
+		bp->brdattr ^= BRD_NEEDS_SMS_VERIFICATION;
+		touched = 1;
 		break;
 
 	    case 'v':

--- a/mbbsd/cache.c
+++ b/mbbsd/cache.c
@@ -233,6 +233,10 @@ postperm_msg(const char *bname)
     assert(0<=i-1 && i-1<MAX_BOARD);
     bp = getbcache(i);
 
+    if (bp->brdattr & BRD_NEEDS_SMS_VERIFICATION)
+        if (!is_user_sms_verified())
+            return "看板限定已驗證台灣門號發/推文";
+
     if (bp->brdattr & BRD_GUESTPOST)
         return NULL;
 


### PR DESCRIPTION
Requirement:
```
- 新增看板權限限制沒有進行 AOTP 者不得發文
```

Changes:
1. Implement `is_taiwan_phone()` which determine if current user is registered phone number.
2. Insert checking registered phone into `const char * postperm_msg(const char *bname)`.
3. Introduce a board configuration `BRD_NEEDS_SMS_VERIFICATION (0x20000000)` for this function.

Screenshots:
TBD, Still try to build without verifydb lib

Remark:
* Please enable `USE_SMS_VERIFICATION`  and flag  `USE_VERIFYDB` when use this function.

TODO:
* Review the post or comment checking flow and write the document.
