### PR TITLE
Improve contact email

### DIFF
--- a/daemon/fromd/Makefile
+++ b/daemon/fromd/Makefile
@@ -15,7 +15,8 @@ FROMD_LDFLAGS = -levent
 .if ${ENABLE_MAXMIND_DB} == "y"
 CFLAGS += -DFROMD_USE_MAXMIND_DB
 FROMD_LDFLAGS += -lmaxminddb
-.elif ${ENABLE_GEOIP_DB} == "y"
+.endif
+.if ${ENABLE_GEOIP_DB} == "y"
 CFLAGS += -DFROMD_USE_GEOIP_DB
 FROMD_LDFLAGS += -lGeoIP
 .endif

--- a/include/common.h
+++ b/include/common.h
@@ -323,10 +323,10 @@
 /* ----------------------------------------------------- */
 
 #define ERR_OK (0)                                      // error code as OK
-#define ERR_EMAIL_CHALLENGE_INPUT_USER_EMAIL (1)
-#define ERR_EMAIL_CHALLENGE_EMAIL_CODE_CHALLENGE (2)
-#define ERR_EMAIL_CHALLENGE_LOAD_USER_EMAIL (3)
-#define ERR_INVALID_PERM (4)
+#define ERR_EMAIL_CHALLENGE_INPUT_USER_EMAIL (-1)
+#define ERR_EMAIL_CHALLENGE_EMAIL_CODE_CHALLENGE (-2)
+#define ERR_EMAIL_CHALLENGE_LOAD_USER_EMAIL (-3)
+#define ERR_INVALID_PERM (-4)
 
 
 #endif

--- a/include/common.h
+++ b/include/common.h
@@ -318,5 +318,15 @@
 
 #define LOG_IF(x, y)    { if ((x)) { y; } else {} }
 
+/* ----------------------------------------------------- */
+/* Errors                                                */
+/* ----------------------------------------------------- */
+
+#define ERR_OK (0)                                      // error code as OK
+#define ERR_EMAIL_CHALLENGE_INPUT_USER_EMAIL (1)
+#define ERR_EMAIL_CHALLENGE_EMAIL_CODE_CHALLENGE (2)
+#define ERR_EMAIL_CHALLENGE_LOAD_USER_EMAIL (3)
+#define ERR_INVALID_PERM (4)
+
 
 #endif

--- a/include/proto.h
+++ b/include/proto.h
@@ -579,6 +579,7 @@ int regform_estimate_queuesize();
 void ensure_user_agreement_version();
 void new_register(void);
 void check_register(void);
+void check_contact_email();
 bool user_has_email(const userec_t *u);
 bool check_email_allow_reject_lists(
     char *email, const char **errmsg, const char **notice_file);

--- a/include/proto.h
+++ b/include/proto.h
@@ -567,6 +567,9 @@ int delete_file_content2(const char *direct, const fileheader_t *fh,
 /* recover */
 void recover_account();
 
+/* email-challenge */
+int email_challenge(const userec_t *u, const char *email_prompt, const char *email_template_fpath);
+
 /* register */
 int u_register(void);
 int bad_user_id(const char *userid);
@@ -859,6 +862,7 @@ int pwcuChessResult	(int sigType, ChessGameResult);
 int pwcuSetChessEloRating(uint16_t elo_rating);
 int pwcuSaveUserFlags	(void);
 int pwcuSetEmail        (const char *email);
+int pwcuSetIsContactEmail(uint8_t is_contact_email);
 int pwcuRegCompleteEmailJustify(const char *email, const char *justify);
 int pwcuRegCompleteJustify    (const char *justify);
 int pwcuRegSetTemporaryJustify(const char *justify, const char *email);

--- a/include/pttstruct.h
+++ b/include/pttstruct.h
@@ -52,7 +52,7 @@ typedef struct chicken_t { /* 128 bytes */
 #define REGLEN     38             /* Length of registration data */
 #define EMAILSZ    50             /* Size of email field */
 
-#define PASSWD_VERSION	4194
+#define PASSWD_VERSION	4195
 
 typedef struct userec_t {
     uint32_t	version;	/* version number of this sturcture, we
@@ -133,7 +133,9 @@ typedef struct userec_t {
     time4_t	timeremovebadpost;/* 上次刪除劣文時間 */
     time4_t	timeviolatelaw;  /* 被開罰單時間 */
 
-    char	pad_tail[28];
+    uint8_t	is_contact_email; /* email 是否是聯絡信箱 */
+
+    char	pad_tail[27];
 } PACKSTRUCT userec_t;
 
 #ifndef NO_CONST_CUSER

--- a/mbbsd/Makefile
+++ b/mbbsd/Makefile
@@ -79,7 +79,7 @@ OBJS+=		screen.o
 .if $(USE_MBBSD_CXX)
 CXXFLAGS+=	-std=c++17 -I$(SRCROOT)/common/fbs
 LDLIBS+=	-lstdc++
-OBJS+=		recover.o register_sms.o \
+OBJS+=		recover.o email_challenge.o register_sms.o \
 		verifydb.o verifydb_info.o verifydb_search.o
 .endif
 

--- a/mbbsd/email_challenge.cc
+++ b/mbbsd/email_challenge.cc
@@ -1,0 +1,251 @@
+/*****
+ * This is mostly based on recover.cc
+ *****/
+extern "C" {
+#include "bbs.h"
+#include "daemons.h"
+}
+
+#if defined(USE_VERIFYDB_ACCOUNT_RECOVERY) || defined(USEREC_EMAIL_IS_CONTACT)
+
+#if defined(USE_VERIFYDB_ACCOUNT_RECOVERY) && !defined(USE_VERIFYDB)
+#   error "USE_VERIFYDB_ACCOUNT_RECOVERY requires USE_VERIFYDB"
+#endif
+
+#include <optional>
+#include <string>
+
+#include "verifydb.h"
+#include "verifydb.fbs.h"
+
+namespace {
+
+constexpr int kMaxErrCnt = 3;
+constexpr size_t kCodeLen = 30;
+
+struct EmailUserHandle {
+  std::string userid;
+  std::string email;
+
+  int64_t generation;
+};
+
+class EmailChallenge {
+public:
+  int Challenge(const userec_t *u, const std::string &email_prompt, const std::string &email_template_fpath);
+
+private:
+  std::optional<EmailUserHandle> user_;
+  std::string email_;
+  std::vector<std::string> all_emails_;
+  int y_ = 2;
+
+  bool LoadUserEmail(const userec_t *u);
+  bool LoadVerifyDbEmail();
+  bool InputUserEmail();
+  bool EmailCodeChallenge(const std::string &email_prompt, const std::string &email_template_fpath);
+
+  static std::optional<std::string> NormalizeEmail(const std::string &email);
+  static bool SendChallengeCode(const std::string &email,
+                                const std::string &code,
+                                const std::string &email_prompt,
+                                const std::string &email_template_fpath);
+  static std::string GenCode(size_t len);
+  static void UserErrorExit();
+};
+
+// static
+std::optional<std::string>
+EmailChallenge::NormalizeEmail(const std::string &email) {
+  auto out = email;
+  for (auto& c : out)
+    c = std::tolower(c);
+  auto idx = out.find('@');
+  if (idx == std::string::npos)
+    return std::nullopt;
+  if (idx != out.rfind('@'))
+    return std::nullopt;
+  return out;
+}
+
+// static
+bool EmailChallenge::SendChallengeCode(const std::string &email,
+                                       const std::string &code,
+                                       const std::string &email_prompt,
+                                       const std::string &email_template_fpath) {
+  std::string subject;
+  subject.append(email_prompt.c_str());
+  subject.append(code);
+  subject.append(" ] @ IP ");
+  subject.append(fromhost);
+  bsmtp(email_template_fpath.c_str(), subject.c_str(), email.c_str(), "non-exist");
+
+  return true;
+}
+
+bool EmailChallenge::LoadUserEmail(const userec_t *u) {
+#ifdef USEREC_EMAIL_IS_CONTACT
+  std::string uemail = u->email;
+  auto email = NormalizeEmail(uemail);
+  if (email) {
+    all_emails_.push_back(email.value());
+  }
+#endif
+
+  return true;
+}
+
+bool EmailChallenge::LoadVerifyDbEmail() {
+  Bytes buf;
+  const VerifyDb::GetReply *reply;
+  if (!verifydb_getuser(user_->userid.c_str(), user_->generation, &buf, &reply))
+    return false;
+
+  if (reply->entry()) {
+    for (const auto *ent : *reply->entry()) {
+      if (ent->vmethod() == VMETHOD_EMAIL && ent->vkey() != nullptr) {
+        auto email = NormalizeEmail(ent->vkey()->str());
+        if (email)
+          all_emails_.push_back(email.value());
+      }
+    }
+  }
+  return true;
+}
+
+// static
+std::string EmailChallenge::GenCode(size_t len) {
+  std::string s(len, '\0');
+  random_text_code(&s[0], s.size());
+  return s;
+}
+
+// static
+void EmailChallenge::UserErrorExit() {
+  vmsg("錯誤次數過多，請重新操作。");
+  exit(0);
+}
+
+bool EmailChallenge::InputUserEmail() {
+  // Input email.
+  char email[EMAILSZ] = {};
+  int errcnt = 0;
+  while (1) {
+    getdata_buf(y_, 0, "認證/聯絡信箱：", email, sizeof(email), DOECHO);
+    strip_blank(email, email);
+    str_lower(email, email);
+    if (*email) {
+      break;
+    }
+    if (++errcnt >= kMaxErrCnt) {
+      return false;
+    }
+    mvprints(y_ + 1, 0, "請重新輸入。");
+    email[0] = '\0';
+  }
+  email_ = email;
+  y_++;
+  move(y_, 0);
+  clrtoeol(); // There might be error message at this line.
+
+  if (!LoadVerifyDbEmail()) {
+    vmsg("系統錯誤，請稍候再試。");
+    exit(0);
+  }
+
+  return true;
+}
+
+bool EmailChallenge::EmailCodeChallenge(const std::string &email_prompt, const std::string &email_template_fpath) {
+  // Generate code.
+  auto code = GenCode(kCodeLen);
+
+  y_++;
+  mvprints(y_, 0, "系統處理中...");
+  doupdate();
+
+  // Check and send recovery code. Don't exit if email doesn't match, so user
+  // can't guess email.
+  bool email_matches = false;
+  for (const auto &email : all_emails_) {
+    if (email == email_) {
+      email_matches = true;
+    }
+  }
+
+  if (email_matches) {
+    // We only want to send email if the user input the matching address.
+    // Silently fail if email is not matching, so that user cannot guess other
+    // user's email address.
+    SendChallengeCode(email_, code, email_prompt, email_template_fpath);
+  }
+  // Add a random 5-10s delay to prevent timing oracle.
+  usleep(5000000 + random() % 5000000);
+  mvprints(y_++, 0, "若您輸入的資料正確，系統已將認證碼寄送至您的信箱。");
+
+  // Input code.
+  char incode[kCodeLen + 1] = {};
+  int errcnt = 0;
+  while (1) {
+    getdata_buf(y_, 0, "請收信後輸入認證碼：", incode, sizeof(incode), DOECHO);
+    if (email_matches && code == std::string(incode))
+      break;
+    if (++errcnt >= kMaxErrCnt)
+      UserErrorExit();
+    mvprints(y_ + 1, 0, "認證碼錯誤！認證碼共有 %d 字元。", (int)kCodeLen);
+    incode[0] = '\0';
+  }
+  y_++;
+  move(y_, 0);
+  clrtoeol(); // There might be error message at this line.
+
+  // Some paranoid checkings, we are about to let user reset their password.
+  if (code.size() != kCodeLen || code != std::string(incode)) {
+    assert(false);
+    exit(1);
+  }
+
+  return true;
+}
+
+int EmailChallenge::Challenge(const userec_t *u, const std::string &email_prompt, const std::string &email_template_fpath) {
+  EmailUserHandle user;
+  user.userid = u->userid;
+  user.generation = u->firstlogin;
+  user_ = user;
+
+  vs_hdr("驗證認證/聯絡信箱");
+
+  if (!LoadUserEmail(u)) {
+    return ERR_EMAIL_CHALLENGE_LOAD_USER_EMAIL;
+  }
+  if (!InputUserEmail()) {
+    return ERR_EMAIL_CHALLENGE_INPUT_USER_EMAIL;
+  }
+  if (!EmailCodeChallenge(email_prompt, email_template_fpath)) {
+    return ERR_EMAIL_CHALLENGE_EMAIL_CODE_CHALLENGE;
+  }
+
+  return ERR_OK;
+}
+
+}  // namespace
+
+int email_challenge(const userec_t *u, const char *email_prompt, const char *email_template_fpath) {
+  if(!HasUserPerm(PERM_LOGINOK)) {
+    vmsg("尚未完成認證！");
+    return ERR_INVALID_PERM;
+  }
+#ifdef USE_REMOTE_CAPTCHA
+  const char *errmsg = remote_captcha();
+  if (errmsg) {
+    vmsg(errmsg);
+    exit(1);
+  }
+#endif
+
+  EmailChallenge ec;
+  return ec.Challenge(u, email_prompt, email_template_fpath);
+}
+
+#endif

--- a/mbbsd/mbbsd.c
+++ b/mbbsd/mbbsd.c
@@ -1246,6 +1246,7 @@ user_login(void)
         check_bad_clients();
 #endif
 	check_register();
+        check_contact_email();
 	pwcuLoginSave();	// is_first_login_of_today is only valid after pwcuLoginSave.
 	// cuser.lastlogin 由 pwcuLoginSave 後值就變了，要看 last_login_time
 	restore_backup();

--- a/mbbsd/passwd.c
+++ b/mbbsd/passwd.c
@@ -244,6 +244,15 @@ pwcuSetEmail(const char *email)
 }
 
 int
+pwcuSetIsContactEmail(uint8_t is_contact_email)
+{
+    PWCU_START();
+    u.is_contact_email = 1;
+    cuser.is_contact_email = 1;
+    PWCU_END();
+}
+
+int
 pwcuRegCompleteJustify(const char *justify)
 {
     PWCU_START();

--- a/mbbsd/passwd.c
+++ b/mbbsd/passwd.c
@@ -247,8 +247,8 @@ int
 pwcuSetIsContactEmail(uint8_t is_contact_email)
 {
     PWCU_START();
-    u.is_contact_email = 1;
-    cuser.is_contact_email = 1;
+    u.is_contact_email = is_contact_email;
+    cuser.is_contact_email = is_contact_email;
     PWCU_END();
 }
 

--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -1698,8 +1698,19 @@ u_register()
 void
 change_contact_email()
 {
+    char orig_email[EMAILSZ] = {};
     char email[EMAILSZ] = {};
+    char subject[IDLEN+STRLEN+1] = {};
+    memcpy(orig_email, cuser.email, sizeof(email));
     memcpy(email, cuser.email, sizeof(email));
+
+    if (!HasUserPerm(PERM_LOGINOK)) {
+      vmsg("尚未完成認證！");
+    }
+
+    if (cuser.is_contact_email && email_challenge(&cuser, " " BBSNAME " - 更改聯絡信箱認證碼 [ ", "etc/changecontactmail") != ERR_OK) {
+        return;
+    }
 
     email_input_t ein = {};
     ein.email = email;
@@ -1715,6 +1726,11 @@ change_contact_email()
 
     // Write.
     pwcuSetEmail(email);
+    pwcuSetIsContactEmail(1);
+
+    // notify-user
+    sprintf(subject, " " BBSNAME " - %s, 您的聯絡信箱已變更", cuser.userid);
+    bsmtp("etc/contactchanged", subject, orig_email, "non-exist");
 
     vmsg("聯絡信箱更新完成。");
 }

--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -48,6 +48,7 @@ typedef struct {
 #define REGISTER_ERR_TOO_MANY_ACCOUNTS (-3)
 #define REGISTER_ERR_CANCEL (-4)
 #define REGISTER_ERR_AGAIN (-5)
+#define REGISTER_ERR_SAME_WITH_ORIG (-6)
 
 typedef struct email_input {
     const userec_t *u;
@@ -645,7 +646,7 @@ register_email_verification(email_input_t *ein)
     // Nothing changed.
     if (!strcmp(email, orig)) {
 	vmsg("E-Mail 與原本相同。");
-	return REGISTER_ERR_CANCEL;
+	return REGISTER_ERR_SAME_WITH_ORIG;
     }
 
     // Send and check regcode.
@@ -1696,6 +1697,26 @@ u_register()
 #ifdef USEREC_EMAIL_IS_CONTACT
 
 void
+check_contact_email()
+{
+    if (!HasUserPerm(PERM_LOGINOK)) {
+        return;
+    }
+    if (cuser.is_contact_email) {
+        return;
+    }
+
+    clear();
+    vs_hdr2(" 未設定聯絡信箱 ", " 您似乎尚未設定聯絡信箱");
+    move(9, 0);
+    outs("  您似乎尚未設定聯絡信箱，\n" ANSI_COLOR(1;33)
+         "  請至 (U) -> (I) ->(M) 設定聯絡信箱" ANSI_RESET "\n"
+         "  忘記密碼時可從聯絡信箱重新設定。\n\n");
+    outs("  如果您目前的信箱就是聯絡信箱，則可設定同一個信箱。\n");
+    pressanykey();
+}
+
+void
 change_contact_email()
 {
     char orig_email[EMAILSZ] = {};
@@ -1705,7 +1726,7 @@ change_contact_email()
     memcpy(email, cuser.email, sizeof(email));
 
     if (!HasUserPerm(PERM_LOGINOK)) {
-      vmsg("尚未完成認證！");
+        vmsg("尚未完成認證！");
     }
 
     if (cuser.is_contact_email && email_challenge(&cuser, " " BBSNAME " - 更改聯絡信箱認證碼 [ ", "etc/changecontactmail") != ERR_OK) {
@@ -1715,14 +1736,19 @@ change_contact_email()
     email_input_t ein = {};
     ein.email = email;
     ein.allow_untrusted = true;
-    if (register_email_verification(&ein) != REGISTER_OK)
-	return;
+    int err = 0;
+    if ((err = register_email_verification(&ein)) != REGISTER_OK) {
+        if(err == REGISTER_ERR_SAME_WITH_ORIG) {
+            pwcuSetIsContactEmail(1);
+        }
+        return;
+    }
 
     // Log.
     char logfn[PATHLEN];
     setuserfile(logfn, FN_USERSECURITY);
     log_filef(logfn, LOG_CREAT, "%s %s (ContactEmail) %s -> %s\n",
-	      Cdatelite(&now), fromhost, cuser.email, email);
+              Cdatelite(&now), fromhost, cuser.email, email);
 
     // Write.
     pwcuSetEmail(email);

--- a/mbbsd/register_sms.cc
+++ b/mbbsd/register_sms.cc
@@ -348,7 +348,7 @@ void SmsValidation::Run() {
       vmsg("系統錯誤，請至 " BN_BUGREPORT " 看板回報");
       return;
     }
-    if (vans("請問您接受使用條款嗎? (Y/n) ") != 'y') {
+    if (vans("請問您接受使用條款嗎? (y/N) ") != 'y') {
       vmsg("操作取消");
       return;
     }

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -420,8 +420,8 @@ violate_law(userec_t * u, int unum)
 	passwd_sync_update(unum, u);
         if (*ans == '1' || *ans == '2')
             delete_allpost(u->userid);
-	post_violatelaw(u->userid, cuser.userid, reason, "罰單處份");
-	mail_violatelaw(u->userid, "站務警察", reason, "罰單處份");
+	post_violatelaw(u->userid, cuser.userid, reason, "罰單處分");
+	mail_violatelaw(u->userid, "站務警察", reason, "罰單處分");
     }
     pressanykey();
 }

--- a/sample/etc/changecontactmail
+++ b/sample/etc/changecontactmail
@@ -1,0 +1,28 @@
+Message below is written in Chinese/Big5.
+If you cannot read Chinese/Big5, skip to English section.
+-------------------------------------------------------------
+親愛的使用者您好:
+
+        您嘗試要更改聯絡信箱,
+        請填入您的認證碼
+        (在主旨上的 [ ] 括號內，共 30 個字)
+        即可通過認證取得所有功能喔~ :)
+        如果有須要服務的地方,
+        請到 SYSOP板, 我們會竭誠為您服務~ :)
+
+						ptt站長群敬上
+
+注意: 若您並沒有更改聯絡信箱, 請直接刪除這封信.
+-------------------------------------------------------------
+Dear user:
+        You are trying to update your contact email.
+        Please input your verification code
+        (which is 30 characters on subject and quoted
+         by square brackets - [ ] )
+	If you have any problem, go contact us at SYSOP.
+
+					PTT Admins
+
+Warning: if you did not request an update, please
+	delete this mail directly.
+-------------------------------------------------------------

--- a/sample/etc/contactchanged
+++ b/sample/etc/contactchanged
@@ -1,0 +1,13 @@
+Message below is written in Chinese/Big5.
+If you cannot read Chinese/Big5, skip to English section.
+-------------------------------------------------------------
+親愛的使用者您好:
+
+        您的聯絡信箱已經變更.
+
+-------------------------------------------------------------
+Dear user,
+
+        This mail is to confirm your contact email has been changed.
+
+-------------------------------------------------------------

--- a/util/Makefile
+++ b/util/Makefile
@@ -25,7 +25,7 @@ CPROG_WITH_UTIL= \
 	chesscountry	tunepasswd	buildir		xchatd		\
 	uhash_loader	timecap_buildref showuser	removebm \
 	redir		permreport	setrole 	update_online \
-	munin		useractive_munin	\
+	munin		useractive_munin migrate_is_contact_email	\
 
 # 下面是 C++ 的程式
 CPP_WITH_UTIL= \

--- a/util/bbsrf.c
+++ b/util/bbsrf.c
@@ -49,6 +49,17 @@ static int showbanfile(const char *filename)
     return fp ? 0 : -1;
 }
 
+static int checkload()
+{
+    if (cpuload(NULL) <= MAX_CPULOAD)
+	return 0;
+
+    fputs("系統過載, 請稍後再來\n", stdout);
+    sleep(10);
+
+    return 1;
+}
+
 int main(int argc, const char **argv)
 {
     int uid;
@@ -74,6 +85,10 @@ int main(int argc, const char **argv)
 
 
     if (!showbanfile(BAN_FILE)) {
+	return 1;
+    }
+
+    if (checkload()) {
 	return 1;
     }
 

--- a/util/migrate_is_contact_email.c
+++ b/util/migrate_is_contact_email.c
@@ -50,7 +50,7 @@ int migrate_is_contact_email(userec_t *rec)
     return 0;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
     int i, fd, fdw;
     userec_t user;

--- a/util/migrate_is_contact_email.c
+++ b/util/migrate_is_contact_email.c
@@ -1,0 +1,89 @@
+#define _UTIL_C_
+#include "bbs.h"
+
+/* 當資料欄位有異動 例如用了舊的欄位 可用這個程式清除舊值 */
+int migrate_is_contact_email(userec_t *rec)
+{
+    char buf[8193] = {};
+    char buf2[4097] = {};
+    char logfn[PATHLEN] = {};
+    FILE *fin = NULL;
+    bool is_contact_email = false;
+
+    if(!rec->userid[0]) {
+        fprintf(stderr, "migrate_is_contact_email: invalid user-id\n");
+        return -1;
+    }
+
+    // Log.
+    sethomefile(logfn, rec->userid, FN_USERSECURITY);
+    fin = fopen(logfn, "r");
+    if(fin == NULL) {
+        fprintf(stderr, "migrate_is_contact_email: unable to open user.security: userid: %s\n", rec->userid); 
+        return -1;
+    }
+ 
+    fprintf(stderr, "to while-loop: userid: %s is_contact_email: %d\n", rec->userid, rec->is_contact_email);
+    while(fgets(buf2, 4096, fin)) {
+        fprintf(stderr, "after fgets: buf2: |%s|\n", buf2);
+        if(strstr(buf2, "(ContactEmail)")) {
+            is_contact_email = true;
+            break;
+        }
+        memcpy(buf + 4096, buf2, 4096);
+        if(strstr(buf, "(ContactEmail)")) {
+            is_contact_email = true;
+            break;
+        }
+        memcpy(buf, buf2, 4096);
+        bzero(buf2, 4096);
+    }
+    fclose(fin);
+
+    if(!is_contact_email) {
+        fprintf(stderr, "migrate_is_contact_email: not is_contact_email: userid: %s\n", rec->userid);
+        return 0;
+    }
+
+    fprintf(stderr, "migrate_is_contact_email: set is_contact_email: userid: %s\n", rec->userid);
+    rec->is_contact_email = 1;
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    int i, fd, fdw;
+    userec_t user;
+
+    setgid(BBSGID);
+    setuid(BBSUID);
+    chdir(BBSHOME);
+
+    if ((fd = open(BBSHOME"/.PASSWDS", O_RDONLY)) < 0){
+	perror("open .PASSWDS error");
+	exit(-1);
+    }
+
+    if ((fdw = OpenCreate(BBSHOME"/.PASSWDS.new", O_WRONLY | O_TRUNC)) < 0){
+	perror("open .PASSWDS.new error");
+	exit(-1);
+    }
+
+    for(i = 0; i < MAX_USERS; i++){
+	if (read(fd, &user, sizeof(user)) != sizeof(user))
+	    break;
+	migrate_is_contact_email(&user);
+	write(fdw, &user, sizeof(user));
+    }
+    close(fd);
+    close(fdw);
+
+    if (i != MAX_USERS)
+	fprintf(stderr, "ERROR\n");
+    else{
+	fprintf(stderr, "DONE\n");
+	system("/bin/mv " BBSHOME "/.PASSWDS " BBSHOME "/.PASSWDS.bak");
+	system("/bin/mv " BBSHOME "/.PASSWDS.new " BBSHOME "/.PASSWDS");
+    }
+    return 0;
+}

--- a/util/reaper.c
+++ b/util/reaper.c
@@ -1,7 +1,8 @@
 #define _UTIL_C_
-#include "bbs.h"
 
-time4_t now;
+#include "bbs.h"
+#include "var.h"
+
 
 #undef MAX_GUEST_LIFE
 #undef MAX_LIFE

--- a/util/uhash_loader.c
+++ b/util/uhash_loader.c
@@ -1,12 +1,11 @@
 /* standalone uhash loader -- jochang */
 #include "bbs.h"
 #include "fnv_hash.h"
+#include "var.h"
 
 void userec_add_to_uhash(int n, userec_t *id, int onfly);
 void fill_uhash(int onfly);
 void load_uhash(void);
-
-SHM_t *SHM;
 
 int main()
 {

--- a/util/writemoney.c
+++ b/util/writemoney.c
@@ -1,9 +1,7 @@
 /* 把 SHM 中的 money 全部寫回 .PASSWDS */
 #define _UTIL_C_
 #include "bbs.h"
-
-time4_t now;
-extern SHM_t   *SHM;
+#include "var.h"
 
 int main()
 {


### PR DESCRIPTION
Currently we can change "contact email" without any "re-verification".
This leads the bad-guys still able to arbitrarily change the contact email once they are able to login,
obsoleting the original purpose of the "contact email".

The original reason that we don't do re-verification 
was because the users already lost "verify-email",
unable to verify the 1st-time contact email,
especially that "verify-email" is restrictive.

I would argue that we don't need to do "re-verify" for the 1st-time "contact email",
but we do want to do "re-verify" once the email becomes "contact email".

This PR add the followings to reflect the change:
1. add is_contact_email in userec_t.
2. add challenge-email to original contact-email if changing the contact-email again.
3. add migrate_is_contact_email.
4. add check_contact_email (to remind the users update the contact-email.)

