### PR TITLE
mbbsd: notify user after resetting password in user configuration

### DIFF
--- a/include/passwd_notify.hpp
+++ b/include/passwd_notify.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+namespace passwdnotify {
+
+void NotifyUser(const std::string &userid, const std::string &fromhost, const std::string &email);
+
+} //namespace

--- a/include/proto.h
+++ b/include/proto.h
@@ -567,6 +567,9 @@ int delete_file_content2(const char *direct, const fileheader_t *fh,
 /* recover */
 void recover_account();
 
+/* passwd_notify */
+void passwd_notify_me();
+
 /* register */
 int u_register(void);
 int bad_user_id(const char *userid);

--- a/mbbsd/Makefile
+++ b/mbbsd/Makefile
@@ -79,7 +79,7 @@ OBJS+=		screen.o
 .if $(USE_MBBSD_CXX)
 CXXFLAGS+=	-std=c++17 -I$(SRCROOT)/common/fbs
 LDLIBS+=	-lstdc++
-OBJS+=		recover.o register_sms.o \
+OBJS+=		recover.o passwd_notify.o register_sms.o \
 		verifydb.o verifydb_info.o verifydb_search.o
 .endif
 

--- a/mbbsd/passwd_notify.cc
+++ b/mbbsd/passwd_notify.cc
@@ -1,0 +1,28 @@
+extern "C" {
+#include "bbs.h"
+#include "daemons.h"
+}
+
+#include "passwd_notify.hpp"
+
+#include <string>
+
+namespace passwdnotify {
+
+void NotifyUser(const std::string &userid,
+                              const std::string &fromhost,
+                              const std::string &email) {
+  std::string subject;
+  subject.append(" " BBSNAME " - ");
+  subject.append(userid);
+  subject.append("(");
+  subject.append(fromhost);
+  subject.append("), 您的密碼已更變");
+  bsmtp("etc/passwdchanged", subject.c_str(), email.c_str(), "non-exist");
+}
+
+} // namespace
+
+void passwd_notify_me() {
+  passwdnotify::NotifyUser(std::string(cuser.userid), std::string(fromhost), std::string(cuser.email));
+}

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -1052,6 +1052,10 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
 	    log_filef(logfn, LOG_CREAT, "%s %s (Passwd)\n",
 		      Cdatelite(&now), adminmode ? "[Admin]" : fromhost);
 	}
+        // passwd notify me.
+        {
+            passwd_notify_me();
+        }
 	break;
 
     case '3':

--- a/sample/etc/passwdchanged
+++ b/sample/etc/passwdchanged
@@ -7,7 +7,8 @@ If you cannot read Chinese/Big5, skip to English section.
 
 	如此為您本人操作, 請忽略此封信.
 
-	如非您本人操作, 請使用重設密碼功能取回帳號.
+	如非您本人操作, 請盡速透過聯絡信箱重置密碼。
+        https://www.ptt.cc/bbs/SYSOP/M.1603325969.A.7F6.html
 
 -------------------------------------------------------------
 Dear user,
@@ -16,7 +17,8 @@ Dear user,
 
 	If it was you, you may discard this email.
 
-	If it was not you, you can use the password reset
-	feature to recover your account.
+	If it was not you, please reset your password
+        with your contact email as soon as possible.
+        https://www.ptt.cc/bbs/SYSOP/M.1603325969.A.7F6.html
 
 -------------------------------------------------------------


### PR DESCRIPTION
1. move AccountRecovery::NotifyUser to passwdnotify::PasswdNotify::NotifyUser.
2. notify user after resetting password in user configuration (in addition to AccountRecovery).
3. add ip in the subject add add how-to-reset-passwd link in the template.