### PR TITLE
mbbsd: remind setting contact-email after successfully login

### DIFF
--- a/daemon/fromd/Makefile
+++ b/daemon/fromd/Makefile
@@ -15,7 +15,8 @@ FROMD_LDFLAGS = -levent
 .if ${ENABLE_MAXMIND_DB} == "y"
 CFLAGS += -DFROMD_USE_MAXMIND_DB
 FROMD_LDFLAGS += -lmaxminddb
-.elif ${ENABLE_GEOIP_DB} == "y"
+.endif
+.if ${ENABLE_GEOIP_DB} == "y"
 CFLAGS += -DFROMD_USE_GEOIP_DB
 FROMD_LDFLAGS += -lGeoIP
 .endif

--- a/include/proto.h
+++ b/include/proto.h
@@ -581,7 +581,11 @@ bool user_has_email(const userec_t *u);
 bool check_email_allow_reject_lists(
     char *email, const char **errmsg, const char **notice_file);
 void register_mail_complete_and_exit();
+
+#ifdef USEREC_EMAIL_IS_CONTACT
+void check_contact_email();
 void change_contact_email();
+#endif // USEREC_EMAIL_IS_CONTACT
 
 /* register_sms */
 void u_sms_verification();

--- a/include/proto.h
+++ b/include/proto.h
@@ -576,6 +576,7 @@ int regform_estimate_queuesize();
 void ensure_user_agreement_version();
 void new_register(void);
 void check_register(void);
+void check_contact_email();
 bool user_has_email(const userec_t *u);
 bool check_email_allow_reject_lists(
     char *email, const char **errmsg, const char **notice_file);
@@ -859,6 +860,7 @@ int pwcuChessResult	(int sigType, ChessGameResult);
 int pwcuSetChessEloRating(uint16_t elo_rating);
 int pwcuSaveUserFlags	(void);
 int pwcuSetEmail        (const char *email);
+int pwcuSetIsContactEmail(uint8_t is_contact_email);
 int pwcuRegCompleteEmailJustify(const char *email, const char *justify);
 int pwcuRegCompleteJustify    (const char *justify);
 int pwcuRegSetTemporaryJustify(const char *justify, const char *email);

--- a/include/pttstruct.h
+++ b/include/pttstruct.h
@@ -52,7 +52,7 @@ typedef struct chicken_t { /* 128 bytes */
 #define REGLEN     38             /* Length of registration data */
 #define EMAILSZ    50             /* Size of email field */
 
-#define PASSWD_VERSION	4194
+#define PASSWD_VERSION	4195
 
 typedef struct userec_t {
     uint32_t	version;	/* version number of this sturcture, we
@@ -133,7 +133,9 @@ typedef struct userec_t {
     time4_t	timeremovebadpost;/* 上次刪除劣文時間 */
     time4_t	timeviolatelaw;  /* 被開罰單時間 */
 
-    char	pad_tail[28];
+    uint8_t	is_contact_email; /* email 是否是聯絡信箱 */
+
+    char	pad_tail[27];
 } PACKSTRUCT userec_t;
 
 #ifndef NO_CONST_CUSER

--- a/mbbsd/mbbsd.c
+++ b/mbbsd/mbbsd.c
@@ -1246,6 +1246,7 @@ user_login(void)
         check_bad_clients();
 #endif
 	check_register();
+        check_contact_email();
 	pwcuLoginSave();	// is_first_login_of_today is only valid after pwcuLoginSave.
 	// cuser.lastlogin 由 pwcuLoginSave 後值就變了，要看 last_login_time
 	restore_backup();

--- a/mbbsd/passwd.c
+++ b/mbbsd/passwd.c
@@ -244,6 +244,15 @@ pwcuSetEmail(const char *email)
 }
 
 int
+pwcuSetIsContactEmail(uint8_t is_contact_email)
+{
+    PWCU_START();
+    u.is_contact_email = is_contact_email;
+    cuser.is_contact_email = is_contact_email;
+    PWCU_END();
+}
+
+int
 pwcuRegCompleteJustify(const char *justify)
 {
     PWCU_START();

--- a/mbbsd/register_sms.cc
+++ b/mbbsd/register_sms.cc
@@ -348,7 +348,7 @@ void SmsValidation::Run() {
       vmsg("系統錯誤，請至 " BN_BUGREPORT " 看板回報");
       return;
     }
-    if (vans("請問您接受使用條款嗎? (Y/n) ") != 'y') {
+    if (vans("請問您接受使用條款嗎? (y/N) ") != 'y') {
       vmsg("操作取消");
       return;
     }

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -420,8 +420,8 @@ violate_law(userec_t * u, int unum)
 	passwd_sync_update(unum, u);
         if (*ans == '1' || *ans == '2')
             delete_allpost(u->userid);
-	post_violatelaw(u->userid, cuser.userid, reason, "罰單處份");
-	mail_violatelaw(u->userid, "站務警察", reason, "罰單處份");
+	post_violatelaw(u->userid, cuser.userid, reason, "罰單處分");
+	mail_violatelaw(u->userid, "站務警察", reason, "罰單處分");
     }
     pressanykey();
 }

--- a/util/Makefile
+++ b/util/Makefile
@@ -25,7 +25,7 @@ CPROG_WITH_UTIL= \
 	chesscountry	tunepasswd	buildir		xchatd		\
 	uhash_loader	timecap_buildref showuser	removebm \
 	redir		permreport	setrole 	update_online \
-	munin		useractive_munin	\
+	munin		useractive_munin migrate_is_contact_email	\
 
 # 下面是 C++ 的程式
 CPP_WITH_UTIL= \

--- a/util/bbsrf.c
+++ b/util/bbsrf.c
@@ -49,6 +49,17 @@ static int showbanfile(const char *filename)
     return fp ? 0 : -1;
 }
 
+static int checkload()
+{
+    if (cpuload(NULL) <= MAX_CPULOAD)
+	return 0;
+
+    fputs("系統過載, 請稍後再來\n", stdout);
+    sleep(10);
+
+    return 1;
+}
+
 int main(int argc, const char **argv)
 {
     int uid;
@@ -74,6 +85,10 @@ int main(int argc, const char **argv)
 
 
     if (!showbanfile(BAN_FILE)) {
+	return 1;
+    }
+
+    if (checkload()) {
 	return 1;
     }
 

--- a/util/migrate_is_contact_email.c
+++ b/util/migrate_is_contact_email.c
@@ -1,0 +1,91 @@
+#define _UTIL_C_
+#include "bbs.h"
+
+/* 當資料欄位有異動 例如用了舊的欄位 可用這個程式清除舊值 */
+int migrate_is_contact_email(userec_t *rec)
+{
+    char buf[8193] = {};
+    char buf2[4097] = {};
+    char logfn[PATHLEN] = {};
+    FILE *fin = NULL;
+    bool is_contact_email = false;
+
+    if(!rec->userid[0]) {
+        fprintf(stderr, "migrate_is_contact_email: invalid user-id\n");
+        return -1;
+    }
+
+    // Log.
+    sethomefile(logfn, rec->userid, FN_USERSECURITY);
+    fin = fopen(logfn, "r");
+    if(fin == NULL) {
+        fprintf(stderr, "migrate_is_contact_email: unable to open user.security: userid: %s\n", rec->userid);
+        return -1;
+    }
+
+    fprintf(stderr, "to while-loop: userid: %s is_contact_email: %d\n", rec->userid, rec->is_contact_email);
+    // here we use buf2 to get the new chars with length < 4096.
+    // (fgets reads at most 4095, and always put \0 in the end.)
+    // set is_contact_email and break if there is already keyword in buf2.
+    // or we concat the buf2 to buf, and check if the keyword exists in buf.
+    // the buf is renewed by putting buf2 to the first 4096 chars.
+    // always bzero buf2 in the end within the loop.
+    while(fgets(buf2, 4096, fin)) {
+        if(strstr(buf2, "(ContactEmail)")) {
+            fprintf(stderr, "found ContactEmail in buf2\n");
+            is_contact_email = true;
+            break;
+        }
+        memcpy(buf + strlen(buf), buf2, 4096);
+        if(strstr(buf, "(ContactEmail)")) {
+            fprintf(stderr, "found ContactEmail in buf\n");
+            is_contact_email = true;
+            break;
+        }
+        memcpy(buf, buf2, 4096);
+        bzero(buf2, 4096);
+    }
+    fclose(fin);
+
+    fprintf(stderr, "migrate_is_contact_email: userid: %s is_contact_email: %d\n", rec->userid, is_contact_email);
+    rec->is_contact_email = is_contact_email ? 1 : 0;
+    return 0;
+}
+
+int main()
+{
+    int i, fd, fdw;
+    userec_t user;
+
+    setgid(BBSGID);
+    setuid(BBSUID);
+    chdir(BBSHOME);
+
+    if ((fd = open(BBSHOME"/.PASSWDS", O_RDONLY)) < 0){
+	perror("open .PASSWDS error");
+	exit(-1);
+    }
+
+    if ((fdw = OpenCreate(BBSHOME"/.PASSWDS.new", O_WRONLY | O_TRUNC)) < 0){
+	perror("open .PASSWDS.new error");
+	exit(-1);
+    }
+
+    for(i = 0; i < MAX_USERS; i++){
+	if (read(fd, &user, sizeof(user)) != sizeof(user))
+	    break;
+	migrate_is_contact_email(&user);
+	write(fdw, &user, sizeof(user));
+    }
+    close(fd);
+    close(fdw);
+
+    if (i != MAX_USERS)
+	fprintf(stderr, "ERROR\n");
+    else{
+	fprintf(stderr, "DONE\n");
+	system("/bin/mv " BBSHOME "/.PASSWDS " BBSHOME "/.PASSWDS.bak");
+	system("/bin/mv " BBSHOME "/.PASSWDS.new " BBSHOME "/.PASSWDS");
+    }
+    return 0;
+}

--- a/util/reaper.c
+++ b/util/reaper.c
@@ -1,7 +1,8 @@
 #define _UTIL_C_
-#include "bbs.h"
 
-time4_t now;
+#include "bbs.h"
+#include "var.h"
+
 
 #undef MAX_GUEST_LIFE
 #undef MAX_LIFE

--- a/util/uhash_loader.c
+++ b/util/uhash_loader.c
@@ -1,12 +1,11 @@
 /* standalone uhash loader -- jochang */
 #include "bbs.h"
 #include "fnv_hash.h"
+#include "var.h"
 
 void userec_add_to_uhash(int n, userec_t *id, int onfly);
 void fill_uhash(int onfly);
 void load_uhash(void);
-
-SHM_t *SHM;
 
 int main()
 {

--- a/util/writemoney.c
+++ b/util/writemoney.c
@@ -1,9 +1,7 @@
 /* 把 SHM 中的 money 全部寫回 .PASSWDS */
 #define _UTIL_C_
 #include "bbs.h"
-
-time4_t now;
-extern SHM_t   *SHM;
+#include "var.h"
 
 int main()
 {


### PR DESCRIPTION
mbbsd: remind setting contact-email after successfully login (in user_login)

mbbsd: add check_contact_email
util: add migrate_is_contact_email

Currently the contact-email is mixed with the register-email, letting us unable
to know whether the email is contact-email or just the register-email.

Adding 1-byte-flag (uint8_t) is_contact_email in userec_t to know whether the email
is contact-email or not.

Setup the flag as long as we change the contact-email (even if the email is the same).

Previously we don't set is_contact_email in userec_t, but we have the logs in user.security.
Use user.security to migrate is_contact_email.

To deploy this update:
1. make all (no install)
2. do migrate_is_contact_email from /home/bbs
3. make install

To discuss:
whether we should increase the SHM version?
considering that there is no real break change with the original version.