### PR TITLE
mbbsd: add email_challenge

### DIFF
--- a/include/email_challenge.hpp
+++ b/include/email_challenge.hpp
@@ -13,11 +13,11 @@ extern "C" {
 
 #include "user_handle.hpp"
 
-void LoadUserEmail(const userec_t &u, std::vector<std::string> &all_emails_);
-bool LoadVerifyDbEmail(const std::optional<UserHandle> &user_,
-                       std::vector<std::string> &all_emails_);
-void EmailCodeChallenge(const std::string &email_,
-                        const std::vector<std::string> &all_emails_,
-                        int &y_);
+void LoadUserEmail(const userec_t &u, std::vector<std::string> &all_emails);
+bool LoadVerifyDbEmail(const std::optional<UserHandle> &user,
+                       std::vector<std::string> &all_emails);
+void EmailCodeChallenge(const std::string &email,
+                        const std::vector<std::string> &all_emails,
+                        int &y);
 
 #endif

--- a/include/email_challenge.hpp
+++ b/include/email_challenge.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+extern "C" {
+#include "bbs.h"
+#include "daemons.h"
+}
+
+#ifdef USE_VERIFYDB_ACCOUNT_RECOVERY
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "user_handle.hpp"
+
+void LoadUserEmail(const userec_t &u, std::vector<std::string> &all_emails_);
+bool LoadVerifyDbEmail(const std::optional<UserHandle> &user_,
+                       std::vector<std::string> &all_emails_);
+void EmailCodeChallenge(const std::string &email_,
+                        const std::vector<std::string> &all_emails_,
+                        int &y_);
+
+#endif

--- a/include/email_challenge.hpp
+++ b/include/email_challenge.hpp
@@ -5,19 +5,23 @@ extern "C" {
 #include "daemons.h"
 }
 
-#ifdef USE_VERIFYDB_ACCOUNT_RECOVERY
-
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "user_handle.hpp"
 
-void LoadUserEmail(const userec_t &u, std::vector<std::string> &all_emails);
-bool LoadVerifyDbEmail(const std::optional<UserHandle> &user,
+namespace email_challenge {
+
+void LoadUserEmail(const userec_t *u, std::vector<std::string> &all_emails);
+bool LoadVerifyDbEmail(const std::optional<user_handle::UserHandle> &user,
                        std::vector<std::string> &all_emails);
-void EmailCodeChallenge(const std::string &email,
+void EmailCodeChallenge(const bool check_email,
+                        const std::string &email,
                         const std::vector<std::string> &all_emails,
+                        const std::string &prompt,
+                        const std::string &ip,
+                        const std::string &filename,
                         int &y);
 
-#endif
+} // namespace email_challenge

--- a/include/proto.h
+++ b/include/proto.h
@@ -228,6 +228,15 @@ void auto_backup(void);
 void restore_backup(void);
 const char *ask_tmpbuf(int y);
 
+/* email-challenge */
+int email_code_challenge(const char *email,
+                         const userec_t *u,
+                         const int y,
+                         const char *prompt,
+                         const char *ip,
+                         const char *filename,
+                         int *out_y);
+
 /* emaildb */
 #ifdef USE_EMAILDB
 int emaildb_check_email (const char *userid, const char *email);
@@ -580,7 +589,7 @@ void check_register(void);
 bool check_email_allow_reject_lists(
     char *email, const char **errmsg, const char **notice_file);
 void register_mail_complete_and_exit();
-int change_contact_email(bool skip_same_email_check);
+int change_contact_email(bool skip_same_email_check, bool require_two_factor_auth);
 
 /* register_sms */
 void u_sms_verification();

--- a/include/user_handle.hpp
+++ b/include/user_handle.hpp
@@ -2,11 +2,13 @@
 
 #include <string>
 
-#ifdef USE_VERIFYDB_ACCOUNT_RECOVERY
+namespace user_handle {
 
 struct UserHandle {
   std::string userid;
   int64_t generation;
 };
 
-#endif
+bool InitUserHandle(const userec_t *u, UserHandle &user);
+
+} // namespace user_handle

--- a/include/user_handle.hpp
+++ b/include/user_handle.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+#ifdef USE_VERIFYDB_ACCOUNT_RECOVERY
+
+struct UserHandle {
+  std::string userid;
+  int64_t generation;
+};
+
+#endif

--- a/mbbsd/Makefile
+++ b/mbbsd/Makefile
@@ -69,7 +69,7 @@ OBJS+=		screen.o
 .if $(USE_MBBSD_CXX)
 CXXFLAGS+=	-std=c++17 -I$(SRCROOT)/common/fbs
 LDLIBS+=	-lstdc++
-OBJS+=		recover.o email_challenge.o register_sms.o \
+OBJS+=		recover.o user_handle.o email_challenge.o register_sms.o \
 		verifydb.o verifydb_info.o verifydb_search.o
 .endif
 

--- a/mbbsd/Makefile
+++ b/mbbsd/Makefile
@@ -69,7 +69,7 @@ OBJS+=		screen.o
 .if $(USE_MBBSD_CXX)
 CXXFLAGS+=	-std=c++17 -I$(SRCROOT)/common/fbs
 LDLIBS+=	-lstdc++
-OBJS+=		recover.o register_sms.o \
+OBJS+=		recover.o email_challenge.o register_sms.o \
 		verifydb.o verifydb_info.o verifydb_search.o
 .endif
 

--- a/mbbsd/email_challenge.cc
+++ b/mbbsd/email_challenge.cc
@@ -1,0 +1,138 @@
+extern "C" {
+#include "bbs.h"
+#include "daemons.h"
+}
+
+#ifdef USE_VERIFYDB_ACCOUNT_RECOVERY
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "verifydb.h"
+#include "verifydb.fbs.h"
+
+#include "user_handle.hpp"
+#include "email_challenge.hpp"
+
+constexpr int kMaxErrCnt = 3;
+constexpr size_t kCodeLen = 30;
+
+// static
+std::optional<std::string>
+NormalizeEmail(const std::string &email) {
+  auto out = email;
+  for (auto& c : out)
+    c = std::tolower(c);
+  auto idx = out.find('@');
+  if (idx == std::string::npos)
+    return std::nullopt;
+  if (idx != out.rfind('@'))
+    return std::nullopt;
+  return out;
+}
+
+void LoadUserEmail(const userec_t &u, std::vector<std::string> &all_emails_) {
+#ifdef USEREC_EMAIL_IS_CONTACT
+  auto email = NormalizeEmail(u.email);
+  if (email)
+    all_emails_.push_back(email.value());
+#endif
+}
+
+bool LoadVerifyDbEmail(const std::optional<UserHandle> &user_,
+                       std::vector<std::string> &all_emails_) {
+  Bytes buf;
+  const VerifyDb::GetReply *reply;
+  if (!verifydb_getuser(user_->userid.c_str(), user_->generation, &buf, &reply))
+    return false;
+
+  if (reply->entry()) {
+    for (const auto *ent : *reply->entry()) {
+      if (ent->vmethod() == VMETHOD_EMAIL && ent->vkey() != nullptr) {
+        auto email = NormalizeEmail(ent->vkey()->str());
+        if (email)
+          all_emails_.push_back(email.value());
+      }
+    }
+  }
+  return true;
+}
+
+// static
+bool SendRecoveryCode(const std::string &email,
+                      const std::string &code) {
+  std::string subject;
+  subject.append(" " BBSNAME " - 重設密碼認證碼 [ ");
+  subject.append(code);
+  subject.append(" ] @ IP ");
+  subject.append(fromhost);
+  bsmtp("etc/recovermail", subject.c_str(), email.c_str(), "non-exist");
+  return true;
+}
+
+// static
+std::string GenCode(size_t len) {
+  std::string s(len, '\0');
+  random_text_code(&s[0], s.size());
+  return s;
+}
+
+// static
+void UserErrorExit() {
+  vmsg("錯誤次數過多，請重新操作。");
+  exit(0);
+}
+
+void EmailCodeChallenge(const std::string &email_,
+                        const std::vector<std::string> &all_emails_,
+                        int &y_) {
+  // Generate code.
+  auto code = GenCode(kCodeLen);
+
+  y_++;
+  mvprints(y_, 0, "系統處理中...");
+  doupdate();
+
+  // Check and send recovery code. Don't exit if email doesn't match, so user
+  // can't guess email.
+  bool email_matches = false;
+  for (const auto &email : all_emails_) {
+    if (email == email_)
+      email_matches = true;
+  }
+
+  if (email_matches) {
+    // We only want to send email if the user input the matching address.
+    // Silently fail if email is not matching, so that user cannot guess other
+    // user's email address.
+    SendRecoveryCode(email_, code);
+  }
+  // Add a random 5-10s delay to prevent timing oracle.
+  usleep(5000000 + random() % 5000000);
+  mvprints(y_++, 0, "若您輸入的資料正確，系統已將認證碼寄送至您的信箱。");
+
+  // Input code.
+  char incode[kCodeLen + 1] = {};
+  int errcnt = 0;
+  while (1) {
+    getdata_buf(y_, 0, "請收信後輸入認證碼：", incode, sizeof(incode), DOECHO);
+    if (email_matches && code == std::string(incode))
+      break;
+    if (++errcnt >= kMaxErrCnt)
+      UserErrorExit();
+    mvprints(y_ + 1, 0, "認證碼錯誤！認證碼共有 %d 字元。", (int)kCodeLen);
+    incode[0] = '\0';
+  }
+  y_++;
+  move(y_, 0);
+  clrtoeol(); // There might be error message at this line.
+
+  // Some paranoid checkings, we are about to let user reset their password.
+  if (code.size() != kCodeLen || code != std::string(incode)) {
+    assert(false);
+    exit(1);
+  }
+}
+
+#endif

--- a/mbbsd/recover.cc
+++ b/mbbsd/recover.cc
@@ -11,19 +11,14 @@ extern "C" {
 
 #include <optional>
 #include <string>
+#include <vector>
 
-#include "verifydb.h"
-#include "verifydb.fbs.h"
+#include "user_handle.hpp"
+#include "email_challenge.hpp"
 
 namespace {
 
 constexpr int kMaxErrCnt = 3;
-constexpr size_t kCodeLen = 30;
-
-struct UserHandle {
-  std::string userid;
-  int64_t generation;
-};
 
 class AccountRecovery {
 public:
@@ -36,18 +31,12 @@ private:
   int y_ = 2;
 
   bool LoadUser(const char *userid);
-  bool LoadVerifyDbEmail();
   void InputUserEmail();
-  void EmailCodeChallenge();
   void ResetPasswd();
 
-  static std::optional<std::string> NormalizeEmail(const std::string &email);
-  static bool SendRecoveryCode(const std::string &email,
-                               const std::string &code);
   static bool SetPasswd(const UserHandle &user, const char *hashed_passwd);
   static void LogToSecurity(const UserHandle &user, const std::string &email);
   static void NotifyUser(const std::string &userid, const std::string &email);
-  static std::string GenCode(size_t len);
   static void UserErrorExit();
 };
 
@@ -68,56 +57,8 @@ bool AccountRecovery::LoadUser(const char *userid) {
   user.generation = u.firstlogin;
   user_ = user;
 
-#ifdef USEREC_EMAIL_IS_CONTACT
-  auto email = NormalizeEmail(u.email);
-  if (email)
-    all_emails_.push_back(email.value());
-#endif
+  LoadUserEmail(u, all_emails_);
 
-  return true;
-}
-
-bool AccountRecovery::LoadVerifyDbEmail() {
-  Bytes buf;
-  const VerifyDb::GetReply *reply;
-  if (!verifydb_getuser(user_->userid.c_str(), user_->generation, &buf, &reply))
-    return false;
-
-  if (reply->entry()) {
-    for (const auto *ent : *reply->entry()) {
-      if (ent->vmethod() == VMETHOD_EMAIL && ent->vkey() != nullptr) {
-        auto email = NormalizeEmail(ent->vkey()->str());
-        if (email)
-          all_emails_.push_back(email.value());
-      }
-    }
-  }
-  return true;
-}
-
-// static
-std::optional<std::string>
-AccountRecovery::NormalizeEmail(const std::string &email) {
-  auto out = email;
-  for (auto& c : out)
-    c = std::tolower(c);
-  auto idx = out.find('@');
-  if (idx == std::string::npos)
-    return std::nullopt;
-  if (idx != out.rfind('@'))
-    return std::nullopt;
-  return out;
-}
-
-// static
-bool AccountRecovery::SendRecoveryCode(const std::string &email,
-                                       const std::string &code) {
-  std::string subject;
-  subject.append(" " BBSNAME " - 重設密碼認證碼 [ ");
-  subject.append(code);
-  subject.append(" ] @ IP ");
-  subject.append(fromhost);
-  bsmtp("etc/recovermail", subject.c_str(), email.c_str(), "non-exist");
   return true;
 }
 
@@ -155,13 +96,6 @@ void AccountRecovery::LogToSecurity(const UserHandle &user,
   msg.append("\n");
 
   post_msg(BN_SECURITY, title.c_str(), msg.c_str(), "[系統安全局]");
-}
-
-// static
-std::string AccountRecovery::GenCode(size_t len) {
-  std::string s(len, '\0');
-  random_text_code(&s[0], s.size());
-  return s;
 }
 
 // static
@@ -209,58 +143,9 @@ void AccountRecovery::InputUserEmail() {
   move(y_, 0);
   clrtoeol(); // There might be error message at this line.
 
-  if (!LoadVerifyDbEmail()) {
+  if (!LoadVerifyDbEmail(user_, all_emails_)) {
     vmsg("系統錯誤，請稍候再試。");
     exit(0);
-  }
-}
-
-void AccountRecovery::EmailCodeChallenge() {
-  // Generate code.
-  auto code = GenCode(kCodeLen);
-
-  y_++;
-  mvprints(y_, 0, "系統處理中...");
-  doupdate();
-
-  // Check and send recovery code. Don't exit if email doesn't match, so user
-  // can't guess email.
-  bool email_matches = false;
-  for (const auto &email : all_emails_) {
-    if (email == email_)
-      email_matches = true;
-  }
-
-  if (email_matches) {
-    // We only want to send email if the user input the matching address.
-    // Silently fail if email is not matching, so that user cannot guess other
-    // user's email address.
-    SendRecoveryCode(email_, code);
-  }
-  // Add a random 5-10s delay to prevent timing oracle.
-  usleep(5000000 + random() % 5000000);
-  mvprints(y_++, 0, "若您輸入的資料正確，系統已將認證碼寄送至您的信箱。");
-
-  // Input code.
-  char incode[kCodeLen + 1] = {};
-  int errcnt = 0;
-  while (1) {
-    getdata_buf(y_, 0, "請收信後輸入認證碼：", incode, sizeof(incode), DOECHO);
-    if (email_matches && code == std::string(incode))
-      break;
-    if (++errcnt >= kMaxErrCnt)
-      UserErrorExit();
-    mvprints(y_ + 1, 0, "認證碼錯誤！認證碼共有 %d 字元。", (int)kCodeLen);
-    incode[0] = '\0';
-  }
-  y_++;
-  move(y_, 0);
-  clrtoeol(); // There might be error message at this line.
-
-  // Some paranoid checkings, we are about to let user reset their password.
-  if (code.size() != kCodeLen || code != std::string(incode)) {
-    assert(false);
-    exit(1);
   }
 }
 
@@ -325,7 +210,7 @@ void AccountRecovery::ResetPasswd() {
 void AccountRecovery::Run() {
   vs_hdr("取回帳號");
   InputUserEmail();
-  EmailCodeChallenge();
+  EmailCodeChallenge(email_, all_emails_, y_);
   ResetPasswd();
 }
 

--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -1755,6 +1755,9 @@ int
 change_contact_email(bool skip_same_email_check)
 {
     char email[EMAILSZ] = {};
+    if (pwcuReload()) {
+        return -1;
+    }
     memcpy(email, cuser.email, sizeof(email));
 
     email_input_t ein = {};

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -714,7 +714,7 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
 #ifdef USEREC_EMAIL_IS_CONTACT
     case 'm':
 	if (!adminmode) {
-	    change_contact_email(0);
+	    change_contact_email(false, true);
 	    return;
 	} else {
 	    char email[EMAILSZ];
@@ -1008,8 +1008,17 @@ uinfo_query(const char *orig_uid, int adminmode, int unum)
 		fail++;
 		break;
 	    }
-#   endif
-#endif
+#       ifdef USE_EMAIL_2FA
+	    int out_y = 0;
+	    if (email_code_challenge(NULL, &cuser, y, BBSNAME " - 重設密碼認證碼",
+                                     fromhost, "etc/resetpasswdmail", &out_y)) {
+		fail++;
+		break;
+	    }
+	    y = out_y;
+#       endif //USE_EMAIL_2FA
+#   endif // REQUIRE_CONTACT_EMAIL_TO_CHANGE_PASSWORD
+#endif // USEREC_EMAIL_IS_CONTACT
             if (!getdata(y++, 0, "請輸入原密碼：", buf, PASS_INPUT_LEN + 1,
                          PASSECHO) ||
 		!checkpasswd(x.passwd, buf)) {

--- a/mbbsd/user_handle.cc
+++ b/mbbsd/user_handle.cc
@@ -1,0 +1,31 @@
+extern "C" {
+#include "bbs.h"
+}
+
+#include <string>
+#include "user_handle.hpp"
+
+namespace user_handle {
+
+// InitUserHandle
+//
+// Initializing user-handle from userec.
+//
+// Params:
+//   u: userec
+//   user: UserHandle
+//
+// Return:
+//   bool: true: ok false: err
+bool InitUserHandle(const userec_t *u, UserHandle &user) {
+  if (u == NULL || !is_validuserid(u->userid)) {
+    return false;
+  }
+
+  user.userid = u->userid;
+  user.generation = u->firstlogin;
+
+  return true;
+}
+
+} // namespace user_handle

--- a/sample/etc/resetcontactmail
+++ b/sample/etc/resetcontactmail
@@ -1,0 +1,27 @@
+Message below is written in Chinese/Big5.
+If you cannot read Chinese/Big5, skip to English section.
+-------------------------------------------------------------
+親愛的使用者您好:
+
+	此封信主旨附上重設聯絡信箱之一次性認證碼,
+	請複製主旨上括號內之字串並回到 BBS 介面貼上,
+	以繼續操作.
+
+	如您未提出重設聯絡信箱之要求,
+	請忽略此封信, 並絕對不要將認證碼告訴其他人!
+	以確保您帳號安全.
+
+-------------------------------------------------------------
+Dear user,
+
+	Please find the one time code on the email subject
+	(random text quoted in the brackets),
+	and copy the code into BBS interface to continue
+	resetting your contact email.
+
+	If you did not request a contact-email reset,
+	please discard this email,
+	and DO NOT tell anyone the code
+	for the protection of your account.
+
+-------------------------------------------------------------

--- a/sample/etc/resetpasswdmail
+++ b/sample/etc/resetpasswdmail
@@ -1,0 +1,27 @@
+Message below is written in Chinese/Big5.
+If you cannot read Chinese/Big5, skip to English section.
+-------------------------------------------------------------
+親愛的使用者您好:
+
+	此封信主旨附上重設密碼之一次性認證碼,
+	請複製主旨上括號內之字串並回到 BBS 介面貼上,
+	以繼續操作.
+
+	如您未提出重設密碼之要求,
+	請忽略此封信, 並絕對不要將認證碼告訴其他人!
+	以確保您帳號安全.
+
+-------------------------------------------------------------
+Dear user,
+
+	Please find the one time code on the email subject
+	(random text quoted in the brackets),
+	and copy the code into BBS interface to continue
+	resetting your password.
+
+	If you did not request a password reset,
+	please discard this email,
+	and DO NOT tell anyone the code
+	for the protection of your account.
+
+-------------------------------------------------------------

--- a/sample/pttbbs.conf
+++ b/sample/pttbbs.conf
@@ -290,6 +290,9 @@
 /* 如果使用者上次 login 在 FORCE_UPDATE_CONTACT_EMAIL_LASTLOGIN 之前, 則重新設定聯絡信箱 */
 //#define FORCE_UPDATE_CONTACT_EMAIL_LASTLOGIN 0
 
+/* 對於重設密碼, 更改聯絡信箱, 忘記密碼, 寄信到既有的聯絡信箱或認證信箱 */
+//#define USE_EMAIL_2FA
+
 /* 前進站畫面 */
 #define INSCREEN \
 "前進站畫面 (請至 pttbbs.conf 修改您的前進站畫面)"


### PR DESCRIPTION
mbbsd: add email_challenge

Currently we verify email again only in AccountRecovery.
We should verify email as well when the user intends to reset the password.

It is possible that we will need to verify the email when changing
the contact-email in the future.
Use email_challenge instead of passwd_challenge for this generalization.

The implementation is based on AccountRecovery::EmailCodeChallenge.

It is better to review #113 before merging this PR,
in that #113 enables us differentiating register-email vs. contact-email.
