### PR TITLE
 fix(initbbs): adjust board order to let bid=1 group exist

### DIFF
--- a/daemon/fromd/Makefile
+++ b/daemon/fromd/Makefile
@@ -15,7 +15,8 @@ FROMD_LDFLAGS = -levent
 .if ${ENABLE_MAXMIND_DB} == "y"
 CFLAGS += -DFROMD_USE_MAXMIND_DB
 FROMD_LDFLAGS += -lmaxminddb
-.elif ${ENABLE_GEOIP_DB} == "y"
+.endif
+.if ${ENABLE_GEOIP_DB} == "y"
 CFLAGS += -DFROMD_USE_GEOIP_DB
 FROMD_LDFLAGS += -lGeoIP
 .endif

--- a/mbbsd/register_sms.cc
+++ b/mbbsd/register_sms.cc
@@ -348,7 +348,7 @@ void SmsValidation::Run() {
       vmsg("系統錯誤，請至 " BN_BUGREPORT " 看板回報");
       return;
     }
-    if (vans("請問您接受使用條款嗎? (Y/n) ") != 'y') {
+    if (vans("請問您接受使用條款嗎? (y/N) ") != 'y') {
       vmsg("操作取消");
       return;
     }

--- a/mbbsd/user.c
+++ b/mbbsd/user.c
@@ -420,8 +420,8 @@ violate_law(userec_t * u, int unum)
 	passwd_sync_update(unum, u);
         if (*ans == '1' || *ans == '2')
             delete_allpost(u->userid);
-	post_violatelaw(u->userid, cuser.userid, reason, "罰單處份");
-	mail_violatelaw(u->userid, "站務警察", reason, "罰單處份");
+	post_violatelaw(u->userid, cuser.userid, reason, "罰單處分");
+	mail_violatelaw(u->userid, "站務警察", reason, "罰單處分");
     }
     pressanykey();
 }

--- a/util/bbsrf.c
+++ b/util/bbsrf.c
@@ -49,6 +49,17 @@ static int showbanfile(const char *filename)
     return fp ? 0 : -1;
 }
 
+static int checkload()
+{
+    if (cpuload(NULL) <= MAX_CPULOAD)
+	return 0;
+
+    fputs("系統過載, 請稍後再來\n", stdout);
+    sleep(10);
+
+    return 1;
+}
+
 int main(int argc, const char **argv)
 {
     int uid;
@@ -74,6 +85,10 @@ int main(int argc, const char **argv)
 
 
     if (!showbanfile(BAN_FILE)) {
+	return 1;
+    }
+
+    if (checkload()) {
 	return 1;
     }
 

--- a/util/initbbs.c
+++ b/util/initbbs.c
@@ -104,12 +104,19 @@ static void initBoards() {
     
     if(fp) {
 	memset(&b, 0, sizeof(b));
-	
+
+	strcpy(b.brdname, "0ClassRoot");
+	strcpy(b.title, ".... Σ分組討論區");
+	b.brdattr = BRD_GROUPBOARD;
+	b.level = PERM_SYSOP;
+	b.gid = 3;
+	newboard(fp, &b);
+
 	strcpy(b.brdname, "SYSOP");
 	strcpy(b.title, "嘰哩 ◎站長好!");
 	b.brdattr = BRD_POSTMASK;
 	b.level = 0;
-	b.gid = 2;
+	b.gid = 3;
 	newboard(fp, &b);
 
 	strcpy(b.brdname, "1...........");
@@ -123,14 +130,14 @@ static void initBoards() {
 	strcpy(b.title, "發電 ◎雜七雜八的垃圾");
 	b.brdattr = 0;
 	b.level = PERM_SYSOP;
-	b.gid = 2;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "Security");
 	strcpy(b.title, "發電 ◎站內系統安全");
 	b.brdattr = 0;
 	b.level = PERM_SYSOP;
-	b.gid = 2;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "2...........");
@@ -144,28 +151,28 @@ static void initBoards() {
 	strcpy(b.title, "嘰哩 ◎跨板式LOCAL新文章");
 	b.brdattr = BRD_POSTMASK;
 	b.level = PERM_SYSOP;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "deleted");
 	strcpy(b.title, "嘰哩 ◎資源回收筒");
 	b.brdattr = 0;
 	b.level = PERM_BM;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "Note");
 	strcpy(b.title, "嘰哩 ◎動態看板及歌曲投稿");
 	b.brdattr = 0;
 	b.level = 0;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "Record");
 	strcpy(b.title, "嘰哩 ◎我們的成果");
 	b.brdattr = 0 | BRD_POSTMASK;
 	b.level = 0;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 	
 	
@@ -173,21 +180,21 @@ static void initBoards() {
 	strcpy(b.title, "嘰哩 ◎呵呵，猜猜我是誰！");
 	b.brdattr = 0;
 	b.level = 0;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "EditExp");
 	strcpy(b.title, "嘰哩 ◎範本精靈投稿區");
 	b.brdattr = 0;
 	b.level = 0;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 
 	strcpy(b.brdname, "ALLHIDPOST");
 	strcpy(b.title, "嘰哩 ◎跨板式LOCAL新文章(隱板)");
 	b.brdattr = BRD_POSTMASK | BRD_HIDE;
 	b.level = PERM_SYSOP;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 	
 #ifdef BN_FIVECHESS_LOG
@@ -195,7 +202,7 @@ static void initBoards() {
 	strcpy(b.title, "棋藝 ◎" BBSNAME "五子棋譜 站上對局全紀錄");
 	b.brdattr = BRD_POSTMASK;
 	b.level = PERM_SYSOP;
-	b.gid = 5;
+	b.gid = 6;
 	newboard(fp, &b);
 #endif
 

--- a/util/initbbs.c
+++ b/util/initbbs.c
@@ -109,7 +109,21 @@ static void initBoards() {
 	strcpy(b.title, ".... Σ分組討論區");
 	b.brdattr = BRD_GROUPBOARD;
 	b.level = PERM_SYSOP;
-	b.gid = 3;
+	b.gid = 2;
+	newboard(fp, &b);
+
+	strcpy(b.brdname, "0_Group");
+	strcpy(b.title, ".... Σ中央政府  《高壓危險,非人可敵》");
+	b.brdattr = BRD_GROUPBOARD;
+	b.level = PERM_SYSOP;
+	b.gid = 1;
+	newboard(fp, &b);
+
+	strcpy(b.brdname, "A_Group");
+	strcpy(b.title, ".... Σ市民廣場     報告  站長  ㄜ！");
+	b.brdattr = BRD_GROUPBOARD;
+	b.level = 0;
+	b.gid = 1;
 	newboard(fp, &b);
 
 	strcpy(b.brdname, "SYSOP");
@@ -119,60 +133,53 @@ static void initBoards() {
 	b.gid = 3;
 	newboard(fp, &b);
 
-	strcpy(b.brdname, "1...........");
-	strcpy(b.title, ".... Σ中央政府  《高壓危險,非人可敵》");
-	b.brdattr = BRD_GROUPBOARD;
-	b.level = PERM_SYSOP;
-	b.gid = 1;
-	newboard(fp, &b);
-	
 	strcpy(b.brdname, "junk");
 	strcpy(b.title, "發電 ◎雜七雜八的垃圾");
 	b.brdattr = 0;
 	b.level = PERM_SYSOP;
-	b.gid = 3;
+	b.gid = 2;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "Security");
 	strcpy(b.title, "發電 ◎站內系統安全");
 	b.brdattr = 0;
 	b.level = PERM_SYSOP;
-	b.gid = 3;
+	b.gid = 2;
 	newboard(fp, &b);
-	
-	strcpy(b.brdname, "2...........");
-	strcpy(b.title, ".... Σ市民廣場     報告  站長  ㄜ！");
-	b.brdattr = BRD_GROUPBOARD;
-	b.level = 0;
-	b.gid = 1;
+
+	strcpy(b.brdname, "ALLHIDPOST");
+	strcpy(b.title, "嘰哩 ◎跨板式LOCAL新文章(隱板)");
+	b.brdattr = BRD_POSTMASK | BRD_HIDE;
+	b.level = PERM_SYSOP;
+	b.gid = 2;
 	newboard(fp, &b);
-	
+
 	strcpy(b.brdname, BN_ALLPOST);
 	strcpy(b.title, "嘰哩 ◎跨板式LOCAL新文章");
 	b.brdattr = BRD_POSTMASK;
 	b.level = PERM_SYSOP;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "deleted");
 	strcpy(b.title, "嘰哩 ◎資源回收筒");
 	b.brdattr = 0;
 	b.level = PERM_BM;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "Note");
 	strcpy(b.title, "嘰哩 ◎動態看板及歌曲投稿");
 	b.brdattr = 0;
 	b.level = 0;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "Record");
 	strcpy(b.title, "嘰哩 ◎我們的成果");
 	b.brdattr = 0 | BRD_POSTMASK;
 	b.level = 0;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	
@@ -180,29 +187,22 @@ static void initBoards() {
 	strcpy(b.title, "嘰哩 ◎呵呵，猜猜我是誰！");
 	b.brdattr = 0;
 	b.level = 0;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 	
 	strcpy(b.brdname, "EditExp");
 	strcpy(b.title, "嘰哩 ◎範本精靈投稿區");
 	b.brdattr = 0;
 	b.level = 0;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 
-	strcpy(b.brdname, "ALLHIDPOST");
-	strcpy(b.title, "嘰哩 ◎跨板式LOCAL新文章(隱板)");
-	b.brdattr = BRD_POSTMASK | BRD_HIDE;
-	b.level = PERM_SYSOP;
-	b.gid = 6;
-	newboard(fp, &b);
-	
 #ifdef BN_FIVECHESS_LOG
 	strcpy(b.brdname, BN_FIVECHESS_LOG);
 	strcpy(b.title, "棋藝 ◎" BBSNAME "五子棋譜 站上對局全紀錄");
 	b.brdattr = BRD_POSTMASK;
 	b.level = PERM_SYSOP;
-	b.gid = 6;
+	b.gid = 3;
 	newboard(fp, &b);
 #endif
 

--- a/util/reaper.c
+++ b/util/reaper.c
@@ -1,7 +1,8 @@
 #define _UTIL_C_
-#include "bbs.h"
 
-time4_t now;
+#include "bbs.h"
+#include "var.h"
+
 
 #undef MAX_GUEST_LIFE
 #undef MAX_LIFE

--- a/util/uhash_loader.c
+++ b/util/uhash_loader.c
@@ -1,12 +1,11 @@
 /* standalone uhash loader -- jochang */
 #include "bbs.h"
 #include "fnv_hash.h"
+#include "var.h"
 
 void userec_add_to_uhash(int n, userec_t *id, int onfly);
 void fill_uhash(int onfly);
 void load_uhash(void);
-
-SHM_t *SHM;
 
 int main()
 {

--- a/util/writemoney.c
+++ b/util/writemoney.c
@@ -1,9 +1,7 @@
 /* 把 SHM 中的 money 全部寫回 .PASSWDS */
 #define _UTIL_C_
 #include "bbs.h"
-
-time4_t now;
-extern SHM_t   *SHM;
+#include "var.h"
 
 int main()
 {


### PR DESCRIPTION
The group whose bid is 1 should be root of `(C)lass 分組討論區`.
Besides, the creation order of these boards determine their bid number

This patch will allow contributors to easier organize boards and groups when creating their new site
and also make pttweb able to find the entry by the route (`/cls/1`) for their new PttBBS site