### PR TITLE
bbslua: fix bbs.getstr(n, 8) causing assertion failure

### DIFF
--- a/mbbsd/bbslua.c
+++ b/mbbsd/bbslua.c
@@ -411,6 +411,8 @@ bl_getstr(lua_State* L)
     if (n > 2)
         pmsg = lua_tostring(L, 3);
 
+    echo &= ~GCARRY; // avoid assertion failure
+
     if (len < 2)
         len = 2;
     if (len >= (int)sizeof(buf))


### PR DESCRIPTION
Without this fix, a user should not run the following BBS-Lua code, otherwise the user will be disconnected immediately.
```lua
--#BBSLUA
bbs.getdata(8,8)
--#BBSLUA
```

### Explanation

When `bbs.getstr(n, echo)` is executed, the echo flag passes through the following functions:

    bl_getstr() -> getdata_str() -> getdata2vgetflag()

However, `getdata2vgetflag()` asserts that `echo` != `GCARRY` (`8`), which did not hold when `bbs.getstr(n, 8)` was executed, thus causing program termination.

`GCARRY` will now be filtered out for avoiding the assertion failure.

This fix is based on [ccns/dreambbs@90e0464c9d](https://github.com/ccns/dreambbs/commit/90e0464c9d3d6d1f3dc14fa2e696608fa9de3e34) and is rewritten in a non-BBS-portable manner for simplicity.

Further references: https://github.com/ccns/dreambbs/wiki/BBS-Lua-Change-zh_tw