### PR TITLE
pfterm: fix broken scrolling when term height > ft.rows 修正終端機高度 > ft.rows 時，畫面捲動壞掉的問題

### DIFF
--- a/mbbsd/pfterm.c
+++ b/mbbsd/pfterm.c
@@ -2187,9 +2187,17 @@ fterm_rawscroll (int dy)
     // we are not going to preserve (rx,ry)
     // so don't use fterm_move*.
     if (dy > 0)
-        fterm_rawcmd2(ft.rows, 1, 1, 'H');
+    {
+        // use a large row number in case terminal height > ft.rows
+        // The terminal height passed to resizeterm() can be unreliable
+        fterm_rawcmd2(9999, 1, 1, 'H');
+    }
     else
+    {
+        fterm_rawcmd2(ft.rows + 1 - ady, 1, 1, 'H');
+        fterm_raws(ESC_STR "[J");
         fterm_rawcmd2(1, 1, 1, 'H');
+    }
 
     for (; ady > 0; ady--)
     {


### PR DESCRIPTION
`fterm_rawscroll()` required that term height == `ft.rows` in order to work properly, but it is not the case when `ft.rows` is a clipped value of term height.\
`fterm_rawscroll()` 原本要求終端機的高度 == `ft.rows` 以正確運作，但此前提在 `ft.rows` 是終端機高度的被限制値時不成立。

`fterm_rawscroll()` now only assumes the term height to be <= 9999.\
現在 `fterm_rawscroll()` 只假設終端機高度 <= 9999。

### Demonstration of the broken scrolling behavior (terminal size: 102x202):
壞掉的捲動行爲示例（終端機大小：102x102）：

https://user-images.githubusercontent.com/37586669/184506762-1a6a088e-d595-47d2-a2a1-94fc460a1310.mp4

- "Up-scrolling" (forward): The bottom line is duplicated.\
  「上捲」（向之後內容捲／向前捲）：畫面底部的行被重複。
- "Down-scrolling" (backward): The screen is not scrolled and only a line near the bottom is changed (and the screen becomes de-synchronized with the internal state of pfterm).\
  「下捲」（向先前內容捲）：畫面不捲動，且只有靠近畫面底部的行有被更新（且畫面與 pfterm 內部狀態變得不同步）。

**Note: The definition of up/down-scrolling in `pfterm.c` is opposite to the usual definition.**
**注意：`pfterm.c` 中，上／下捲的定義與通常定義相反。**

(In the usual definition, the "up/down" in "up/down-scrolling" refers to the moving direction of the screen range, not the moving direction of the screen content. However, the "up/down-scrolling" in pfterm is defined by the latter.)\
（在通常定義中，「上／下捲」的「上／下」指的是畫面範圍的移動方向，不是畫面內容的移動方向。但 pfterm 的「上／下捲」以後者定義。）

This phenomenon occurs when the terminal height > 100. (100 is the limit of terminal height of Ptt)\
此現象在終端機高度 > 100 時發生。（100 是 Ptt 的終端機高度限制）