### PR TITLE
util: fix inappropriate semicolon in expire.c

### DIFF
--- a/util/expire.c
+++ b/util/expire.c
@@ -182,18 +182,19 @@ life_t  db, table[MAX_BOARD], *key;
 
 void toexpire(char *brdname)
 {
-    if( brdname[0] > ' ' && brdname[0] != '.' ){
-	key = NULL;
+    if (!is_valid_brdname(brdname));
+	return;
 
-	if( count )
-	    key = (life_t *)bsearch(brdname, table, count,
-				    sizeof(life_t), (QCAST)strcasecmp);
-	if( key == NULL )
-	    key = &db;
+    key = NULL;
 
-	strcpy(key->bname, brdname);
-	expire(key);
-    }
+    if( count )
+	key = (life_t *)bsearch(brdname, table, count,
+		sizeof(life_t), (QCAST)strcasecmp);
+    if( key == NULL )
+	key = &db;
+
+    strcpy(key->bname, brdname);
+    expire(key);
 }
 
 void visitdir(char c)

--- a/util/expire.c
+++ b/util/expire.c
@@ -182,7 +182,7 @@ life_t  db, table[MAX_BOARD], *key;
 
 void toexpire(char *brdname)
 {
-    if (!is_valid_brdname(brdname));
+    if (!is_valid_brdname(brdname))
 	return;
 
     key = NULL;


### PR DESCRIPTION
Based on c95077384, we need to remove this inappropriate semicolon.