### PR TITLE
mbbsd: only call change_contact_email when USEREC_EMAIL_IS_CONTACT is defined

### DIFF
--- a/mbbsd/register.c
+++ b/mbbsd/register.c
@@ -1182,6 +1182,7 @@ check_register(void)
     char fn[PATHLEN];
     int ret = 0;
 
+#ifdef USEREC_EMAIL_IS_CONTACT
     // 確認一定要有聯絡信箱
     if (!is_valid_email(cuser.email)) {
         more("etc/ensurevalidcontactemail", NA);
@@ -1198,6 +1199,7 @@ check_register(void)
         while ((ret = change_contact_email(1)));
 #endif //FORCE_UPDATE_CONTACT_EMAIL_LASTLOGIN
     }
+#endif //USEREC_EMAIL_IS_CONTACT
 
     // 已經通過的就不用了
     if (HasUserPerm(PERM_LOGINOK) || HasUserPerm(PERM_SYSOP))


### PR DESCRIPTION
if we call `change_contact_email()` function when USEREC_EMAIL_IS_CONTACT is not defined in pttbbs.conf, 
it will cause undefined reference error when compile this source.
```
+PFTERM +CONVERT ccache clang vers.c -o mbbsd admin.o assess.o edit.o xyz.o var.o vote.o voteboard.o comments.o  bbs.o announce.o read.o board.o brc.o mail.o record.o fav.o captcha.o user.o acl.o register.o passwd.o emaildb.o mbbsd.o io.o term.o telnet.o nios.o friend.o talk.o ccw.o stuff.o kaede.o convert.o name.o syspost.o cache.o cal.o  menu.o vtuikit.o psb.o more.o pmore.o ordersong.o angel.o timecap.o  chess.o chc.o chc_tab.o ch_go.o ch_gomo.o ch_dark.o ch_reversi.o ch_conn6.o chicken.o gamble.o pfterm.o -Os -Wl,--as-needed -Wl,--sort-common -L../common/bbs -L../common/sys  -L../common/osdep -lcmbbs -lcmsys -losdep 
/usr/bin/ld: register.o: in function `check_register':
/home/bbs/pttbbs/mbbsd/register.c:1198: undefined reference to `change_contact_email'
/usr/bin/ld: /home/bbs/pttbbs/mbbsd/register.c:1191: undefined reference to `change_contact_email'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
*** Error code 1
```

Note: We've found this behavior in this issue: bbsdocker/imageptt#3