### PR TITLE
mbbsd: timestamp in verifydb_change_userid

### DIFF
--- a/mbbsd/verifydb.cc
+++ b/mbbsd/verifydb.cc
@@ -203,7 +203,7 @@ int verifydb_change_userid(const char *from_userid, const char *to_userid,
       // (by using an empty vkey). Also, make sure the insert is successful
       // before deleting.
       if (verifydb_set(to_userid, entry->generation(), entry->vmethod(),
-                       entry->vkey()->c_str(), entry->timestamp() < 0) ||
+                       entry->vkey()->c_str(), entry->timestamp()) < 0 ||
           verifydb_set(from_userid, entry->generation(), entry->vmethod(), "",
                        0) < 0)
         ok = false;


### PR DESCRIPTION
This seems to be a typo.

With the existing implementation, new timestamp is always generated if the userid is changed.
This PR can be updated to be as 0 to make this policy consistent.

