### PR TITLE
mbbsd: fix assertion failure when calling a_menu from vedit2

### DIFF
--- a/mbbsd/announce.c
+++ b/mbbsd/announce.c
@@ -1081,7 +1081,7 @@ isvisible_man(const menu_t * me)
 	return 0;
     if (fhdr->filemode & FILE_HIDE)
     {
-	if (currstat == ANNOUNCE ||
+	if (currstat == ANNOUNCE || currstat == EDITEXP ||
 	    !is_hidden_board_friend(me->bid, currutmp->uid))
 	    return 0;
     }


### PR DESCRIPTION
在編輯文章的界面按 Ctrl-G 進入編輯輔助器

如果嘗試進入非公開的條目就會直接 crash

因為從 vedit2() 呼叫 a_menu() 時 lastbid 是 0

當 is_hidden_board_friend() 檢查時會掛在
assert(0<=bid-1 && bid-1<MAX_BOARD)

解決辦法是當 currstat == EDITEXP 時就直接返回
(跟佈告欄的方式相似)

![image](https://user-images.githubusercontent.com/107286981/235348526-d3b2e509-5478-4859-966d-7d6d8cf8b793.png)
