### PR TITLE
fix pfterm fterm_rawscroll() output incompatibility by passing true term size from term_resize() 修正 pfterm fterm_rawscroll() 輸出之不相容，透過從 term_resize() 給入眞實終端機大小

### DIFF
--- a/docs/pfterm.txt
+++ b/docs/pfterm.txt
@@ -6,8 +6,9 @@
     API Manual
     函式說明手冊
 
-    VERSION 1.1
-    最後更新: 2007/12/24 18:00   piaip
+    VERSION 1.2
+    v1.1:     2007/12/24 18:00   piaip
+    最後更新: 2023/06/01 01:55   IID
 
 =============================================================================
 
@@ -32,8 +33,15 @@
 
 // initialization   初始化
 void    initscr     (void);                 初始系統
-int     resizeterm  (int rows, int cols);   調整視窗大小為(rows,col)
+int     resizeterm  (int rows, int cols);   調整畫面大小為(rows,cols)
+int     resizeterm_within(                  調整顯示範圍為終端機畫面的部分區域：
+            int rows, int cols,             顯示範圍大小為(rows,cols)，
+            int rows_full, int cols_full);  實際終端機則為(rows_full,cols_full)
 int     endwin      (void);                 結束系統
+
+            resizeterm() 假設顯示範圍大小 (rows,cols) 即為實際終端機大小。
+            但當顯示範圍與實際終端機大小不符時，畫面捲動行為將會不正確；
+            可用 resizeterm_within() 指定實際終端機大小 (rows_full,cols_full)。
 
 // cursor           游標
 void    getyx       (int *y, int *x);       取得目前游標位置

--- a/include/proto.h
+++ b/include/proto.h
@@ -595,6 +595,7 @@ ChessInfo* reversi_replay(FILE* fp);
 /* screen/pfterm (ncurses-like) */
 void initscr	(void);
 int  resizeterm	(int rows, int cols);
+int  resizeterm_within(int rows, int cols, int rows_full, int cols_full);
 void getyx	(int *py, int *px);
 void move	(int y, int x);
 void clear	(void);

--- a/mbbsd/screen.c
+++ b/mbbsd/screen.c
@@ -79,6 +79,16 @@ initscr(void)
 }
 
 int
+resizeterm_within(int rows, int cols, int rows_full GCC_UNUSED, int cols_full GCC_UNUSED)
+{
+    // FIXME: rows_full instead of b_lines should be used for forward scrolling
+    if (rows != t_lines || cols != t_columns) {
+        return resizeterm(rows, cols);
+    }
+    return 0;
+}
+
+int
 resizeterm(int w, int h)
 {
     screenline_t   *new_picture;

--- a/mbbsd/term.c
+++ b/mbbsd/term.c
@@ -52,18 +52,17 @@ void term_resize(int w, int h)
 
 
     /* make sure reasonable size */
-    h = MAX(24, MIN(100, h));
-    w = MAX(80, MIN(200, w));
+    int h_crop = MAX(24, MIN(100, h));
+    int w_crop = MAX(80, MIN(200, w));
 
-    if (w != t_columns || h != t_lines)
+    // invoke terminal system resize
+    resizeterm_within(h_crop, w_crop, h, w);
+    if (w_crop != t_columns || h_crop != t_lines)
     {
-	// invoke terminal system resize
-	resizeterm(h, w);
-
-	t_lines = h;
-	t_columns = w;
 	dorefresh = 1;
     }
+    t_lines = h_crop;
+    t_columns = w_crop;
     b_lines = t_lines - 1;
     p_lines = t_lines - 4;
 


### PR DESCRIPTION
Some third-party apps assume that the cursor-moving escapes have in-bound coord, which had become untrue due to [1847f5b9d7](https://github.com/ptt/pttbbs/commit/1847f5b9d756dad5b44d308054a18ce4f93f65a9) (ptt/pttbbs#120).\
一些第三方應用程式假設游標移動控制碼的座標在畫面內，此假設由於 [1847f5b9d7](https://github.com/ptt/pttbbs/commit/1847f5b9d756dad5b44d308054a18ce4f93f65a9) (ptt/pttbbs#120) 而不再成立。

To address this, a new function `resizeterm_within()` is introduced to the API of pfterm to allow passing the full terminal size along with the display region size. \
爲解決此問題，pfterm 的應用程式介面引入了新函式 `resizeterm_within()` 以讓實際終端機大小能同時與顯示範圍大小傳入。

This partially reverts the forward scrolling handling of [1847f5b9d7](https://github.com/IepIweidieng/pttbbs/commit/1847f5b9d756dad5b44d308054a18ce4f93f65a9). \
這部份地反轉了 [1847f5b9d7](https://github.com/IepIweidieng/pttbbs/commit/1847f5b9d756dad5b44d308054a18ce4f93f65a9) 中的向後捲動處理。

See the commit message for details.\
細節請見提交訊息。

If this issue is not fixed on the server side, third-party apps will need to treat the coordinates exceeding the bottom-most row as the bottom-most row to behave correctly.\
若伺服器方未修正，第三方 app 須將超出畫面最底行的座標視爲畫面最底行以正確運作。

Relevant reports from sub-sites of PTT:\
批踢踢各分站內有關此問題的相關回報：

* `[請問] PTT star 某些文章自動捲到頁尾` [#1aP984sy (EZsoft)](https://www.ptt.cc/bbs/EZsoft/M.1684312580.A.DBC.html) (PTT Star)
* `[推薦] PTT Star瀏覽器` [#1SASLqsL (EZsoft)](https://www.ptt.cc/bbs/EZsoft/M.1546241396.A.D95.html) 推文
* `[問題] 有沒有JPTT使用者覺得今天怪怪的` [#1aOw9-ks (MobileComm)](https://www.ptt.cc/bbs/MobileComm/M.1684251262.A.BB6.html) (disconnect; JPTT)
* `R: [問題] 有沒有JPTT使用者覺得今天怪怪的` [#1aP5dq8Z (MobileComm)](https://www.ptt.cc/bbs/MobileComm/M.1684298228.A.223.html)
* `[問題] 伺服器回傳錯誤的座標位置 esc[9999;1H` [#1aP5_o5- (SYSOP)](https://www.ptt.cc/bbs/SYSOP/M.1684299762.A.17E.html)
* `[問題] JPTT無故斷線` [#1aP5Dygp (AppsForBBS)](https://www.ptt.cc/bbs/AppsForBBS/M.1684296572.A.AB3.html) (disconnect; JPTT)
* `[問題] MoPtt是不是有問題？` [#1aPBt2Us (iOS)](https://www.ptt.cc/bbs/iOS/M.1684323778.A.7B6.html) (crash; Mo PTT)
* `[系統] PTT系統連線卡卡?` #1aOvxv4- (SYSOP) \[[ptt2.cc](https://term.ptt2.cc)]

There are over 41 relevant reports from the board Gossiping (until 2023-05-18 20:00 UTC+8). Please refer to the following note for the issue state of third-party apps for details:\
Gossiping 板有 41 則以上相關報告（截至 2023-05-18 20:00 UTC+8），請見對於第三方 app 狀況的詳細整理：<https://hackmd.io/@IID/pfterm-scroll-incompat>
