### PR TITLE
make: avoid strlcpy/strlcat redefinition on glibc 2.38+

### DIFF
--- a/include/osdep.h
+++ b/include/osdep.h
@@ -18,13 +18,6 @@
 #include <sys/file.h>      /* for flock() */
 #include <strings.h>       /* for strcasecmp() */
 
-#if !defined(__has_builtin) || !__has_builtin(strlcpy)
-#define NEED_STRLCPY
-#endif
-#if !defined(__has_builtin) || !__has_builtin(strlcat)
-#define NEED_STRLCAT
-#endif
-
 #define NEED_SETPROCTITLE
 
 #elif ! defined(__FreeBSD__) || ! defined( DARWIN )

--- a/pttbbs.mk
+++ b/pttbbs.mk
@@ -101,6 +101,24 @@ CXXFLAGS+=	-DNO_FORK
 ######################################
 # Settings for common libraries
 
+# This will attempt to compile a small test program that only calls strlcpy()
+HAVE_STRLCPY != \
+       echo '\#include <string.h>\nint main(){char b[4];strlcpy(b,"x",4);}' | \
+       ${CC} -x c -o /dev/null - 2>/dev/null && echo 1 || echo 0
+
+HAVE_STRLCAT != \
+       echo '\#include <string.h>\nint main(){char b[4]="x";strlcat(b,"y",4);}' | \
+       ${CC} -x c -o /dev/null - 2>/dev/null && echo 1 || echo 0
+
+.if ${HAVE_STRLCPY} != 1
+CFLAGS+= -DNEED_STRLCPY=1
+CXXFLAGS+= -DNEED_STRLCPY=1
+.endif
+.if ${HAVE_STRLCAT} != 1
+CFLAGS+= -DNEED_STRLCAT=1
+CXXFLAGS+= -DNEED_STRLCAT=1
+.endif
+
 #######################################################################
 # conditional configurations and optional modules
 #######################################################################


### PR DESCRIPTION
Newer glibc (≥ 2.38) provides built-in implementations of strlcpy() and strlcat(). Projects that also define these functions will now fail to build due to symbol redefinition conflicts.

This patch is trying to verify whether strlcpy()/strlcat() are available at compile time and only compiles the compatibility implementation when missing. (e.g. glibc is older 2.38)

ref: <https://sourceware.org/git/?p=glibc.git;a=commit;h=454a20c8756c9c1d55419153255fc7692b3d2199>

related previous discussion: #135
related build test: <https://github.com/bbsdocker/imageptt/actions/runs/19000701482>