### PR TITLE
fix(board): restore limit for visible-user list ; fix: 修正特別名單上限抓錯索引的問題

### DIFF
--- a/mbbsd/friend.c
+++ b/mbbsd/friend.c
@@ -16,6 +16,7 @@ static const unsigned int friend_max[8] = {
     MAX_POST_INFO,  /* FRIEND_POST     */
     MAX_NAMELIST,   /* FRIEND_SPECIAL  */
     MAX_FRIEND,     /* FRIEND_CANVOTE  */
+    0,              /* deprecated: BOARD_WATER */
     MAX_FRIEND,     /* BOARD_VISABLE   */
 };
 /* 雖然好友跟壞人名單都是 * 2 但是一次最多load到shm只能有128 */


### PR DESCRIPTION
After BOARD_WATER was removed, the entries in friend_max[] became
misaligned, leaving the limit for BOARD_VISABLE as zero. This prevents
users from being added after the first entry.

Keep a placeholder for the deprecated BOARD_WATER index to restore the
correct BOARD_VISABLE limit.

補回已棄用的 BOARD_WATER 索引占位，修正看板可見名單無法繼續新增成員的問題。