### PR TITLE
docs: remove accidental `\n` literals in README.md and UPDATING.md 移除 README.md 與 UPDATING.md 結尾殘留的 `\n`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@
   - `postd/`：文章記錄服務 (experimental)
   - `regmaild/`：註冊 Email 驗證與寄送服務
   - `utmpd/`：UTMP 快取伺服器 (experimental)
-  - `wsproxy/`：WebSocket 至 Telnet BBS 代理轉接服務 (experimental)\n
+  - `wsproxy/`：WebSocket 至 Telnet BBS 代理轉接服務 (experimental)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -280,4 +280,4 @@ trunk 與 stable 第一次分枝。
 ## [from OpenPTT 1.0.2]
 
 `.DIR` 有變，`.BOARDS` 變 `.BRD`, ...
-請見 PTT2 PttSrc 板\n
+請見 PTT2 PttSrc 板


### PR DESCRIPTION
Remove the accidental `\n` string literals left at the end of `README.md` and `UPDATING.md`. 
These appear to be minor typos left over from commit 72ff854.

移除 `README.md` 與 `UPDATING.md` 檔案結尾殘留的 `\n` 字元。
這似乎是在 72ff854 更新時不小心遺留下來的排版失誤。